### PR TITLE
Chore: 초기 DB 환경 세팅 및 QueryDSL, MapStruct 공통 설정 [#11]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hrbank3/hrbank3/mapper/GenericMapper.java
+++ b/src/main/java/com/hrbank3/hrbank3/mapper/GenericMapper.java
@@ -1,0 +1,24 @@
+package com.hrbank3.hrbank3.mapper;
+
+import java.util.List;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+public interface GenericMapper<D, E> {
+  // Entity -> Dto로 변환
+  D toDto(E entity);
+
+  // Dto -> Entity로 변환
+  E toEntity(D dto);
+
+  // Entity 리스트 -> Dto 리스트로 변환
+  List<D> toDtoList(List<E> entityList);
+
+  // Dto 리스트 -> Entity 리스트로 변환
+  List<E> toEntity(List<D> dtoList);
+
+  // null 값일 경우 무시하고 아닌 경우에만 치환
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateDto(D dto, @MappingTarget E entity);
+}

--- a/src/main/java/com/hrbank3/hrbank3/mapper/GenericMapper.java
+++ b/src/main/java/com/hrbank3/hrbank3/mapper/GenericMapper.java
@@ -16,9 +16,9 @@ public interface GenericMapper<D, E> {
   List<D> toDtoList(List<E> entityList);
 
   // Dto 리스트 -> Entity 리스트로 변환
-  List<E> toEntity(List<D> dtoList);
+  List<E> toEntityList(List<D> dtoList);
 
   // null 값일 경우 무시하고 아닌 경우에만 치환
   @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-  void updateDto(D dto, @MappingTarget E entity);
+  void updateFromDto(D dto, @MappingTarget E entity);
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/hrbank
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema-postgres.sql
+
+  jpa:
+    hibernate:
+      ddl-auto: none # Entity 완성 후 변경
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        show_sql: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    username: sa
+    password:
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema-h2.sql
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -1,0 +1,59 @@
+-- 1. departments 테이블 생성
+CREATE TABLE IF NOT EXISTS departments (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(255),
+    established_date DATE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- 2. files 테이블 생성
+CREATE TABLE IF NOT EXISTS files (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    original_name VARCHAR(255) NOT NULL,
+    stored_name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(50) NOT NULL,
+    size BIGINT NOT NULL,
+    storage_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- 3. employees 테이블 생성
+CREATE TABLE IF NOT EXISTS employees (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    employee_number VARCHAR(50) NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    department_id BIGINT NOT NULL,
+    position VARCHAR(50) NOT NULL,
+    status VARCHAR(10) NOT NULL,
+    hire_date DATE NOT NULL,
+    profile_image_id BIGINT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments(id),
+    CONSTRAINT fk_profile_image FOREIGN KEY (profile_image_id) REFERENCES files(id)
+);
+
+-- 4. employee_audit_histories 테이블 생성
+CREATE TABLE IF NOT EXISTS employee_audit_histories (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    audit_type VARCHAR(20) NOT NULL,
+    target_employee_no VARCHAR(50) NOT NULL,
+    changed_content TEXT NOT NULL,
+    memo VARCHAR(255),
+    ip_address VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- 5. backup_histories 테이블 생성
+CREATE TABLE IF NOT EXISTS backup_histories (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    worker VARCHAR(45) NOT NULL,
+    started_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    ended_at TIMESTAMP WITH TIME ZONE,
+    status VARCHAR(10) NOT NULL,
+    file_id BIGINT,
+    CONSTRAINT fk_backup_file FOREIGN KEY (file_id) REFERENCES files(id)
+);

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -1,0 +1,59 @@
+-- 1. departments 테이블 생성
+CREATE TABLE IF NOT EXISTS departments (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(255),
+    established_date DATE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- 2. files 테이블 생성
+CREATE TABLE IF NOT EXISTS files (
+    id BIGSERIAL PRIMARY KEY,
+    original_name VARCHAR(255) NOT NULL,
+    stored_name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(50) NOT NULL,
+    size BIGINT NOT NULL,
+    storage_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+-- 3. employees 테이블 생성
+CREATE TABLE IF NOT EXISTS employees (
+    id BIGSERIAL PRIMARY KEY,
+    employee_number VARCHAR(50) NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    department_id BIGINT NOT NULL,
+    position VARCHAR(50) NOT NULL,
+    status VARCHAR(10) NOT NULL,
+    hire_date DATE NOT NULL,
+    profile_image_id BIGINT,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments(id),
+    CONSTRAINT fk_profile_image FOREIGN KEY (profile_image_id) REFERENCES files(id)
+);
+
+-- 4. employee_audit_histories 테이블 생성
+CREATE TABLE IF NOT EXISTS employee_audit_histories (
+    id BIGSERIAL PRIMARY KEY,
+    audit_type VARCHAR(20) NOT NULL,
+    target_employee_no VARCHAR(50) NOT NULL,
+    changed_content JSONB NOT NULL,
+    memo VARCHAR(255),
+    ip_address VARCHAR(50) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+-- 5. backup_histories 테이블 생성
+CREATE TABLE IF NOT EXISTS backup_histories (
+    id BIGSERIAL PRIMARY KEY,
+    worker VARCHAR(45) NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    ended_at TIMESTAMPTZ,
+    status VARCHAR(10) NOT NULL,
+    file_id BIGINT,
+    CONSTRAINT fk_backup_file FOREIGN KEY (file_id) REFERENCES files(id)
+);


### PR DESCRIPTION
## 관련 이슈
- closes #11 

## 변경사항
- 로컬(H2) 및 개발(PostgreSQL) DB 환경 분리 (`application-local.yaml`, `application-dev.yaml` 세팅)
  - H2 로컬 테스트 환경 설정과 PostgreSQL 운영 환경 설정 중 H2의 TIMESTAMPTZ, BIGSERIAL, JSONB에서 오류가 발생하여  schema-h2.sql과 schema-postgres.sql로 나누어서 테이블을 생성하였습니다.
- QueryDSL 및 MapStruct 라이브러리 의존성 추가
- MapStruct 공통 매퍼(`GenericMapper`) 인터페이스 구현

## 개발환경 실행 시 주의사항
- 보안을 위해 `application-dev.yml`의 DB 접속 계정 정보를 코드에 직접 적지 않고, 환경 변수(`${DB_USER}`, `${DB_PASSWORD}`)로 처리했습니다.
- `dev` 프로파일로 서버를 실행 전 환경변수를 세팅해야합니다.

**[인텔리제이 환경 변수 세팅 방법]**
1. 우측 상단 서버 실행 버튼 옆의 **[Edit Configurations...]** 클릭
2. **Environment variables** 칸에 아래 내용 입력
   👉 `DB_USER=postgres(또는 본인계정);DB_PASSWORD=본인비밀번호`
   (비밀번호를 따로 설정하지 않으셨다면 `DB_PASSWORD=` 처럼 뒤를 비워두시면 됩니다!)

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인

## 스크린샷 (선택)
<img width="798" height="26" alt="스크린샷 2026-04-15 오후 1 57 09" src="https://github.com/user-attachments/assets/30d95857-834b-4c29-ae88-948c6e543cdc" />
<img width="1507" height="778" alt="스크린샷 2026-04-15 오후 5 14 26" src="https://github.com/user-attachments/assets/0e9db076-0fd0-4d49-a09f-37adae445aa1" />
