### PR TITLE
Feat: 백업 도메인 및 레포지토리 구현 [#15]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/config/QuerydslConfig.java
+++ b/src/main/java/com/hrbank3/hrbank3/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.hrbank3.hrbank3.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
@@ -1,0 +1,65 @@
+package com.hrbank3.hrbank3.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "backup_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BackupHistory {
+
+  @Id
+  @Column
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String worker;
+
+  @Column(nullable = false)
+  private Instant startedAt;
+
+  @Column
+  private Instant endedAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private BackupStatus status;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "file_id")
+  // TODO : File 엔티티 들어오면 맵핑
+  private File file;
+
+  public BackupHistory(String worker) {
+    this.worker = worker;
+    this.startedAt = Instant.now();
+    this.status = BackupStatus.IN_PROGRESS;
+  }
+
+  public void updateComplete(File file) {
+    this.status = BackupStatus.COMPLETE;
+    this.endedAt = Instant.now();
+    this.file = file;
+  }
+
+  public void updateFail(File file) {
+    this.status = BackupStatus.FAILED;
+    this.endedAt = Instant.now();
+    this.file = file;
+  }
+}

--- a/src/main/java/com/hrbank3/hrbank3/entity/BackupStatus.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/BackupStatus.java
@@ -1,0 +1,8 @@
+package com.hrbank3.hrbank3.entity;
+
+public enum BackupStatus {
+  IN_PROGRESS, // 진행중
+  COMPLETE, // 완료
+  FAILED, // 실패
+  SKIPPED // 건너뜀
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.hrbank3.hrbank3.repository;
+
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import com.hrbank3.hrbank3.repository.custom.BackupHistoryRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// JpaRepository와 BackupHistoryRepositoryCustom 둘 다 상속해서 기본 CRUD와 QueryDSL 커스텀 쿼리 같이 쓰기
+public interface BackupHistoryRepository extends JpaRepository<BackupHistory, Long>,
+    BackupHistoryRepositoryCustom {
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
@@ -1,10 +1,16 @@
 package com.hrbank3.hrbank3.repository;
 
 import com.hrbank3.hrbank3.entity.BackupHistory;
+import com.hrbank3.hrbank3.entity.BackupStatus;
 import com.hrbank3.hrbank3.repository.custom.BackupHistoryRepositoryCustom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // JpaRepository와 BackupHistoryRepositoryCustom 둘 다 상속해서 기본 CRUD와 QueryDSL 커스텀 쿼리 같이 쓰기
 public interface BackupHistoryRepository extends JpaRepository<BackupHistory, Long>,
     BackupHistoryRepositoryCustom {
+
+  // 백업 필요 여부를 판단하기 위한 메소드
+  // 가장 최근 완료된 배치 작업 시간 이후 직원 데이터가 변경되었는지 조회
+  Optional<BackupHistory> findTopByStatusOrderByStartedAtDesc(BackupStatus status);
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
@@ -1,7 +1,6 @@
 package com.hrbank3.hrbank3.repository.condition;
 
 import com.hrbank3.hrbank3.entity.BackupStatus;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +15,7 @@ public class BackupHistorySearchCondition {
   private ZonedDateTime startedAtFrom;
   private ZonedDateTime startedAtTo;
   private BackupStatus status;
+  private BackupHistorySortType sortType; // 정렬 조건
+  private Long lastId; // 이전 페이지 마지막 요소 ID
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
@@ -1,0 +1,20 @@
+package com.hrbank3.hrbank3.repository.condition;
+
+import com.hrbank3.hrbank3.entity.BackupStatus;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BackupHistorySearchCondition {
+  private String worker;
+  // 프론트에선 한국 기준으로 보여주므로 ZonedDateTime 사용
+  private ZonedDateTime startedAtFrom;
+  private ZonedDateTime startedAtTo;
+  private BackupStatus status;
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySortType.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySortType.java
@@ -1,0 +1,11 @@
+package com.hrbank3.hrbank3.repository.condition;
+
+// 정렬 타입을 enum으로 만들어서 유효하지 않은 값 입력 받지 않게
+public enum BackupHistorySortType {
+  STARTED_AT_ASC,
+  STARTED_AT_DESC,
+  ENDED_AT_ASC,
+  ENDED_AT_DESC,
+  STATUS_ASC,
+  STATUS_DESC
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryCustom.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.hrbank3.hrbank3.repository.custom;
+
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import com.hrbank3.hrbank3.repository.condition.BackupHistorySearchCondition;
+import java.util.List;
+
+public interface BackupHistoryRepositoryCustom {
+  List<BackupHistory> findAllByCondition(BackupHistorySearchCondition condition);
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.hrbank3.hrbank3.repository.custom;
 
 import com.hrbank3.hrbank3.entity.BackupStatus;
 import com.hrbank3.hrbank3.entity.QBackupHistory;
+import com.hrbank3.hrbank3.repository.condition.BackupHistorySortType;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -10,24 +12,33 @@ import com.hrbank3.hrbank3.entity.BackupHistory;
 import com.hrbank3.hrbank3.repository.condition.BackupHistorySearchCondition;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+@Repository
 @RequiredArgsConstructor
 public class BackupHistoryRepositoryImpl implements BackupHistoryRepositoryCustom{
   private final JPAQueryFactory queryFactory;
   private final QBackupHistory backupHistory = QBackupHistory.backupHistory;
 
+  // 프로로타입 기준으로 페이지 사이즈 10으로 상수 고정
+  private static final int PAGE_SIZE = 10;
+
   @Override
   public List<BackupHistory> findAllByCondition(BackupHistorySearchCondition condition) {
     return queryFactory
         .selectFrom(backupHistory)
+        //where()에 여러 조건을 넣으면 QueryDSL이 자동으로 AND로 연결하고, 조건메서드가 null을 반환하면 조건 무시함
         .where(
             workerContains(condition.getWorker()),
             startedAtBetween(condition.getStartedAtFrom(), condition.getStartedAtTo()),
-            statusEq(condition.getStatus())
+            statusEq(condition.getStatus()),
+            cursorCondition(condition.getLastId(), condition.getSortType())
         )
+        .orderBy(resolveOrderBy(condition.getSortType()))
+        .limit(PAGE_SIZE)
         .fetch();
-    //where()에 여러 조건을 넣으면 QueryDSL이 자동으로 AND로 연결하고, 조건메서드가 null을 반환하면 조건 무시함
+
   }
 
   // BooleanExpression은 sql의 where 조건절을 객체로 표현한 것
@@ -58,5 +69,34 @@ public class BackupHistoryRepositoryImpl implements BackupHistoryRepositoryCusto
         ? backupHistory.status.eq(status)
         : null;
   }
+
+  // 어디서부터 가져올지 정하는 메소드
+  // gt = great than, 오름차순이면 마지막 id 이후 데이터 가져와야함 -> id > lastId
+  // lt = less than, 내림차순이면 마지막 id 이전 데이터 가져와야함 -> id < lastId
+  private BooleanExpression cursorCondition(Long lastId, BackupHistorySortType sortType) {
+    if (lastId == null) return null;
+
+    return switch (sortType) {
+      case STARTED_AT_ASC, ENDED_AT_ASC, STATUS_ASC -> backupHistory.id.gt(lastId);
+      case STARTED_AT_DESC, ENDED_AT_DESC, STATUS_DESC -> backupHistory.id.lt(lastId);
+    };
+  }
+
+  // 어떤 순서로 정렬할지 정하는 메서드
+  private OrderSpecifier<?> resolveOrderBy(BackupHistorySortType sortType) {
+    // 기본값
+    if (sortType == null) return backupHistory.startedAt.desc();
+
+    return switch (sortType) {
+      case STARTED_AT_ASC -> backupHistory.startedAt.asc();
+      case STARTED_AT_DESC -> backupHistory.startedAt.desc();
+      case ENDED_AT_ASC -> backupHistory.endedAt.asc().nullsLast();
+      case ENDED_AT_DESC -> backupHistory.endedAt.desc().nullsLast();
+      case STATUS_ASC -> backupHistory.status.asc();
+      case STATUS_DESC -> backupHistory.status.desc();
+    };
+
+  }
+
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.hrbank3.hrbank3.repository.custom;
+
+import com.hrbank3.hrbank3.entity.BackupStatus;
+import com.hrbank3.hrbank3.entity.QBackupHistory;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import com.hrbank3.hrbank3.repository.condition.BackupHistorySearchCondition;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+public class BackupHistoryRepositoryImpl implements BackupHistoryRepositoryCustom{
+  private final JPAQueryFactory queryFactory;
+  private final QBackupHistory backupHistory = QBackupHistory.backupHistory;
+
+  @Override
+  public List<BackupHistory> findAllByCondition(BackupHistorySearchCondition condition) {
+    return queryFactory
+        .selectFrom(backupHistory)
+        .where(
+            workerContains(condition.getWorker()),
+            startedAtBetween(condition.getStartedAtFrom(), condition.getStartedAtTo()),
+            statusEq(condition.getStatus())
+        )
+        .fetch();
+    //where()에 여러 조건을 넣으면 QueryDSL이 자동으로 AND로 연결하고, 조건메서드가 null을 반환하면 조건 무시함
+  }
+
+  // BooleanExpression은 sql의 where 조건절을 객체로 표현한 것
+  // WHERE worker LIKE '%문자열%' 과 같은 기능
+  // 작업자 부분 일치 조회를 위한 메소드
+  private BooleanExpression workerContains(String worker) {
+    return StringUtils.hasText(worker)
+        ? backupHistory.worker.contains(worker)
+        : null;
+  }
+
+  // 시작시간 범위 일치 조회를 위한 메소드
+  private BooleanExpression startedAtBetween(ZonedDateTime from, ZonedDateTime to) {
+    if (from == null && to == null) return null;
+
+    // 조회를 위한 Instant 변환
+    Instant fromInstant = from != null ? from.toInstant() : null;
+    Instant toInstant = to != null ? to.toInstant() : null;
+
+    if (fromInstant == null) return backupHistory.startedAt.loe(toInstant);
+    if (toInstant == null) return backupHistory.startedAt.goe(fromInstant);
+    return backupHistory.startedAt.between(fromInstant, toInstant);
+  }
+
+  // 상태 완전 일치 조회를 위한 메소드
+  private BooleanExpression statusEq(BackupStatus status) {
+    return status != null
+        ? backupHistory.status.eq(status)
+        : null;
+  }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,10 @@ spring:
   application:
     name: hrbank3
   profiles:
-    active: local
+    active: dev
+  mvc:
+    format:
+      date-time: iso # 프론트 파싱을 위한 설정 -> 테스트 필요
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 관련 이슈
- closes #15 

## 변경사항
- BackupHistoryEntity 구현 
    - 46줄 private File file; 코드에서 File의 경우 FileMetaData 엔티티로 추후 이름 바꿔 맵핑할 예정. 
    - BackupStatus Enum으로 상태 관리: IN_PROGRESS, COMPLETE, FAILED, SKIPPED
- BackupHistoryRepository 구현
    - 백업 필요 여부를 판단하는 메소드 findTopByStatusOrderByStartedAtDesc를 JPA Repository 쿼리로 구현
    - 상세 조회(작업자, 시작시간을 기준으로 하는 범위, 상태) 조건과 정렬 조건을 같이 하기 위해 QueryDSL 커스텀 쿼리 작성. 
    - 조건이 많아서 가독성을 위해 SearchCondition 클래스로 분리함. 
    - 정렬 타입이 많고 유효하지 않은 값 입력 방지를 위해 enum으로 분리: STARTED_AT_ASC,  STARTED_AT_DESC, ENDED_AT_ASC, ENDED_AT_DESC, STATUS_ASC, STATUS_DESC
    - 커스텀 인터페이스에 findAllByCondition 메소드를 정의하고 Impl 클래스에 구현.

## 테스트
- [x] API 문서(Swagger) 확인

## 스크린샷 (선택)
