### PR TITLE
Feat: 전역 예외 처리 공통 뼈대 세팅

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hrbank3/hrbank3/common/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.hrbank3.hrbank3.common.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+    LocalDateTime timestamp,
+    int status,
+    String message,
+    String details
+) {
+
+  public static ErrorResponse of(int status, String message, String details) {
+    return new ErrorResponse(LocalDateTime.now(), status, message, details);
+  }
+}

--- a/src/main/java/com/hrbank3/hrbank3/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hrbank3/hrbank3/common/exception/ErrorResponse.java
@@ -1,15 +1,15 @@
 package com.hrbank3.hrbank3.common.exception;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record ErrorResponse(
-    LocalDateTime timestamp,
+    Instant timestamp,
     int status,
     String message,
     String details
 ) {
 
   public static ErrorResponse of(int status, String message, String details) {
-    return new ErrorResponse(LocalDateTime.now(), status, message, details);
+    return new ErrorResponse(Instant.now(), status, message, details);
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hrbank3/hrbank3/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.hrbank3.hrbank3.common.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  /// 개발 중 발생하는 에러 핸들링 추가
+
+  // 나머지 모든 서버 에러 500 Internal Server Error
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+    log.error("Internal Server Error: ", e);
+
+    ErrorResponse response = ErrorResponse.of(
+        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+        "서버 내부 오류가 발생했습니다.",
+        request.getRequestURI()
+    );
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #2 

## 변경사항
- **공통 에러 응답 객체(`ErrorResponse`) 추가**
  - API명세에 맞추어 `timestamp`, `status`, `message`, `details` 4가지 필드를 가진 Record 구조로 생성했습니다.
- **전역 예외 처리기(`GlobalExceptionHandler`) 추가**
  - 오버 엔지니어링을 피하기 위해 불필요한 커스텀 예외 생성은 지양하고, 자바 기본 예외를 활용하는 방식으로 구현했습니다.
  개발 완료 이후 필요시 리팩터링 진행하겠습니다.
  - 현재는 예상치 못한 서버 에러(`Exception.class`, 500)만 공통으로 낚아채어 로깅(`log.error`)하도록 세팅했습니다.
  - 나머지 에러 핸들링은 앞으로 서비스 로직을 개발하며 필요시에 점진적으로 추가할 예정입니다.
  

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인

## 스크린샷 (선택)
