### PR TITLE
Feat: 백업 판단 로직 구현 및 이력 등록 서비스 구현 [#21]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
@@ -30,8 +30,10 @@ public class BackupHistoryController {
   })
   @PostMapping
   public ResponseEntity<BackupHistoryDto> create(HttpServletRequest request) {
-    String worker = request.getRemoteAddr(); // IP 주소
+    String worker = request.getHeader("X-Forwarded-For"); // 헤더값으로 실제 클라이언트 ip 받기
+    if (worker == null || worker.isBlank()) {
+      worker = request.getRemoteAddr(); // 헤더 없으면 직접 연결하여 ip 받음
+    }
     return ResponseEntity.ok(backupHistoryService.create(worker));
   }
-
 }

--- a/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
@@ -1,0 +1,37 @@
+package com.hrbank3.hrbank3.controller;
+
+import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
+import com.hrbank3.hrbank3.service.BackupHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "데이터 백업 관리", description = "데이터 백업 관리 API")
+@RestController
+@RequestMapping("/api/backups")
+@RequiredArgsConstructor
+public class BackupHistoryController {
+
+  private final BackupHistoryService backupHistoryService;
+
+  @Operation(summary = "데이터 백업 생성", description = "데이터 백업을 생성합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "백업 생성 성공"),
+      @ApiResponse(responseCode = "409", description = "이미 진행 중인 백업이 있음"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @PostMapping
+  public ResponseEntity<BackupHistoryDto> create(HttpServletRequest request) {
+    String worker = request.getRemoteAddr(); // IP 주소
+    return ResponseEntity.ok(backupHistoryService.create(worker));
+  }
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/backupHistory/BackupHistoryDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/backupHistory/BackupHistoryDto.java
@@ -1,0 +1,15 @@
+package com.hrbank3.hrbank3.dto.backupHistory;
+
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public record BackupHistoryDto(
+    Long id,
+    String worker,
+    ZonedDateTime startedAt, // Instant에서 ZonedDateTime 변환
+    ZonedDateTime endedAt,
+    String status,
+    Long fileId // FileMetaData에서 id만 추출
+) {
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/backupHistory/CursorPageResponseBackupDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/backupHistory/CursorPageResponseBackupDto.java
@@ -1,0 +1,31 @@
+package com.hrbank3.hrbank3.dto.backupHistory;
+
+import java.util.List;
+
+public record CursorPageResponseBackupDto(
+    List<BackupHistoryDto> content,
+    String nextCursor,
+    Long nextIdAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {
+  public static CursorPageResponseBackupDto of(
+      List<BackupHistoryDto> content,
+      boolean hasNext,
+      long totalElements
+  ) {
+    Long nextIdAfter = hasNext ? content.get(content.size() - 1).id() : null;
+    String nextCursor = nextIdAfter != null ? String.valueOf(nextIdAfter) : null;
+
+    return new CursorPageResponseBackupDto(
+        content,
+        nextCursor,
+        nextIdAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
+  }
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
@@ -44,14 +44,27 @@ public class BackupHistory {
   @JoinColumn(name = "file_id")
   private FileMetadata file;
 
-  public BackupHistory(String worker) {
-    this.worker = worker;
-    this.startedAt = Instant.now();
-    this.status = BackupStatus.IN_PROGRESS;
+  // 정적 팩토리 메서드 방식
+  public static BackupHistory ofInProgress(String worker) {
+    BackupHistory history = new BackupHistory();
+    history.worker = worker;
+    history.startedAt = Instant.now();
+    history.status = BackupStatus.IN_PROGRESS;
+    return history;
+  }
+
+  // 스킵할땐 시작시간=끝시간=현재시각
+  public static BackupHistory ofSkipped(String worker) {
+    BackupHistory history = new BackupHistory();
+    history.worker = worker;
+    history.startedAt = Instant.now();
+    history.endedAt = Instant.now();
+    history.status = BackupStatus.SKIPPED;
+    return history;
   }
 
   public void updateComplete(FileMetadata file) {
-    this.status = BackupStatus.COMPLETE;
+    this.status = BackupStatus.COMPLETED;
     this.endedAt = Instant.now();
     this.file = file;
   }

--- a/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/BackupHistory.java
@@ -42,8 +42,7 @@ public class BackupHistory {
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id")
-  // TODO : File 엔티티 들어오면 맵핑
-  private File file;
+  private FileMetadata file;
 
   public BackupHistory(String worker) {
     this.worker = worker;
@@ -51,13 +50,13 @@ public class BackupHistory {
     this.status = BackupStatus.IN_PROGRESS;
   }
 
-  public void updateComplete(File file) {
+  public void updateComplete(FileMetadata file) {
     this.status = BackupStatus.COMPLETE;
     this.endedAt = Instant.now();
     this.file = file;
   }
 
-  public void updateFail(File file) {
+  public void updateFail(FileMetadata file) {
     this.status = BackupStatus.FAILED;
     this.endedAt = Instant.now();
     this.file = file;

--- a/src/main/java/com/hrbank3/hrbank3/entity/BackupStatus.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/BackupStatus.java
@@ -2,7 +2,7 @@ package com.hrbank3.hrbank3.entity;
 
 public enum BackupStatus {
   IN_PROGRESS, // 진행중
-  COMPLETE, // 완료
+  COMPLETED, // 완료
   FAILED, // 실패
   SKIPPED // 건너뜀
 }

--- a/src/main/java/com/hrbank3/hrbank3/mapper/BackupHistoryMapper.java
+++ b/src/main/java/com/hrbank3/hrbank3/mapper/BackupHistoryMapper.java
@@ -1,0 +1,33 @@
+package com.hrbank3.hrbank3.mapper;
+
+import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface BackupHistoryMapper extends GenericMapper<BackupHistoryDto, BackupHistory> {
+
+  // 서울 기준시간 상수로 정의
+  ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  @Mapping(target = "fileId", source = "file.id") // 객체에서 아이디만 꺼내기
+  BackupHistoryDto toDto(BackupHistory entity);
+
+  @Mapping(target = "file", ignore = true) // fileId로 file 객체를 만들 수 없으므로 MapStruct가 무시하게 하고 Service에서 처리 후 넘겨줌
+  BackupHistory toEntity(BackupHistoryDto dto);
+
+
+  // MapStruct는 매핑시 타입이 맞지 않으면 같은 Mapper 안에 변환 메서드가 있는지 찾고 자동으로 끼워넣음 그걸 위해 메소드 정의
+  default ZonedDateTime toZonedDateTime(Instant instant) {
+    return instant == null ? null : instant.atZone(KST);
+  }
+
+  default Instant toInstant(ZonedDateTime zonedDateTime) {
+    return zonedDateTime == null ? null : zonedDateTime.toInstant();
+  }
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/BackupHistoryRepository.java
@@ -13,4 +13,7 @@ public interface BackupHistoryRepository extends JpaRepository<BackupHistory, Lo
   // 백업 필요 여부를 판단하기 위한 메소드
   // 가장 최근 완료된 배치 작업 시간 이후 직원 데이터가 변경되었는지 조회
   Optional<BackupHistory> findTopByStatusOrderByStartedAtDesc(BackupStatus status);
+
+  // 현재 진행중인 백업이 있나 확인
+  boolean existsByStatus(BackupStatus status);
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -1,10 +1,14 @@
 package com.hrbank3.hrbank3.repository;
 
 import com.hrbank3.hrbank3.entity.Employee;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
   // 기본적인 CRUD는 JpaRepository가 기본 제공함
   boolean existsByEmail(String email);
+
+  // 특정 시간 이후 변경된 직원 존재 여부 - BackupHistoryService에서 사용함
+  boolean existsByUpdatedAtAfter(Instant lastBackupTime);
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/condition/BackupHistorySearchCondition.java
@@ -17,5 +17,5 @@ public class BackupHistorySearchCondition {
   private BackupStatus status;
   private BackupHistorySortType sortType; // 정렬 조건
   private Long lastId; // 이전 페이지 마지막 요소 ID
-
+  private int pageSize;
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/BackupHistoryRepositoryImpl.java
@@ -21,9 +21,6 @@ public class BackupHistoryRepositoryImpl implements BackupHistoryRepositoryCusto
   private final JPAQueryFactory queryFactory;
   private final QBackupHistory backupHistory = QBackupHistory.backupHistory;
 
-  // 프로로타입 기준으로 페이지 사이즈 10으로 상수 고정
-  private static final int PAGE_SIZE = 10;
-
   @Override
   public List<BackupHistory> findAllByCondition(BackupHistorySearchCondition condition) {
     return queryFactory
@@ -36,7 +33,7 @@ public class BackupHistoryRepositoryImpl implements BackupHistoryRepositoryCusto
             cursorCondition(condition.getLastId(), condition.getSortType())
         )
         .orderBy(resolveOrderBy(condition.getSortType()))
-        .limit(PAGE_SIZE)
+        .limit(condition.getPageSize()) // 서비스에서 PAGE_SIZE + 1 로 넘어옴
         .fetch();
 
   }

--- a/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
@@ -1,0 +1,21 @@
+package com.hrbank3.hrbank3.service;
+
+import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
+import java.util.List;
+
+public interface BackupHistoryService {
+
+  BackupHistoryDto create(String worker);
+
+  // TODO 이후 구현
+//  BackupHistoryDto findById(Long id);
+//
+//  List<BackupHistoryDto> findAll();
+//
+//  BackupHistoryDto update(Long id);
+//
+//  void delete(Long id);
+
+
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
@@ -1,7 +1,6 @@
 package com.hrbank3.hrbank3.service;
 
 import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
-import java.util.List;
 
 public interface BackupHistoryService {
 

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -1,7 +1,7 @@
 package com.hrbank3.hrbank3.service.basic;
 
 import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
-import com.hrbank3.hrbank3.employee.repository.EmployeeRepository;
+import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import com.hrbank3.hrbank3.entity.BackupHistory;
 import com.hrbank3.hrbank3.entity.BackupStatus;
 import com.hrbank3.hrbank3.mapper.BackupHistoryMapper;

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -51,9 +51,7 @@ public class BasicBackupHistoryService implements BackupHistoryService {
 
     Instant lastBackupTime = lastCompleted.get().getEndedAt();
     // 마지막 백업 완료된 시간 이후 직원 데이터가 변경됐는지 확인하는 메소드
-    // TODO : employeeRepository 구현체 들어오면 해당 메소드 추가해야됨
- //   return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
-    return false; // TODO : 오류가 나지 않게 임의로 설정, 추후 삭제
+    return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
   }
 
   // TODO : 이후 메서드 구현

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -29,15 +29,12 @@ public class BasicBackupHistoryService implements BackupHistoryService {
     boolean backupNeeded = isBackupNeeded();
 
     // 백업 필요 없으면 skipped 상태로 저장 후 종료
-    if (!backupNeeded) {
-      BackupHistory skipped = BackupHistory.ofSkipped(worker);
-      backupHistoryRepository.save(skipped);
-      return backupHistoryMapper.toDto(skipped);
-    } else { //필요하면 IN_PROGRESS 상태로 등록
-      BackupHistory history = BackupHistory.ofInProgress(worker);
-      backupHistoryRepository.save(history);
-      return backupHistoryMapper.toDto(history);
-    }
+    BackupHistory history = backupNeeded
+        ? BackupHistory.ofInProgress(worker)
+        : BackupHistory.ofSkipped(worker);
+
+    BackupHistory savedHistory = backupHistoryRepository.save(history);
+    return backupHistoryMapper.toDto(savedHistory);
   }
 
   // 백업 필요한지 판단 로직

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -25,11 +25,21 @@ public class BasicBackupHistoryService implements BackupHistoryService {
   // create
   @Transactional
   public BackupHistoryDto create(String worker) {
-    // 백업 필요 여부 판단
-    boolean backupNeeded = isBackupNeeded();
+
+    // IN_PROGRESS 중복 체크
+    boolean isInProgress = backupHistoryRepository.existsByStatus(BackupStatus.IN_PROGRESS);
+
+    if (isInProgress) {
+      throw new IllegalStateException("이미 진행 중인 백업이 있습니다.");
+    }
+
+    // worker null 체크
+    if (worker == null || worker.isBlank()) {
+      throw new IllegalArgumentException("작업자 정보가 없습니다.");
+    }
 
     // 백업 필요 없으면 skipped 상태로 저장 후 종료
-    BackupHistory history = backupNeeded
+    BackupHistory history = isBackupNeeded()
         ? BackupHistory.ofInProgress(worker)
         : BackupHistory.ofSkipped(worker);
 

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -52,7 +52,8 @@ public class BasicBackupHistoryService implements BackupHistoryService {
     Instant lastBackupTime = lastCompleted.get().getEndedAt();
     // 마지막 백업 완료된 시간 이후 직원 데이터가 변경됐는지 확인하는 메소드
     // TODO : employeeRepository 구현체 들어오면 해당 메소드 추가해야됨
-    return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
+ //   return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
+    return false; // TODO : 오류가 나지 않게 임의로 설정, 추후 삭제
   }
 
   // TODO : 이후 메서드 구현

--- a/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/basic/BasicBackupHistoryService.java
@@ -1,0 +1,59 @@
+package com.hrbank3.hrbank3.service.basic;
+
+import com.hrbank3.hrbank3.dto.backupHistory.BackupHistoryDto;
+import com.hrbank3.hrbank3.employee.repository.EmployeeRepository;
+import com.hrbank3.hrbank3.entity.BackupHistory;
+import com.hrbank3.hrbank3.entity.BackupStatus;
+import com.hrbank3.hrbank3.mapper.BackupHistoryMapper;
+import com.hrbank3.hrbank3.repository.BackupHistoryRepository;
+import com.hrbank3.hrbank3.service.BackupHistoryService;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BasicBackupHistoryService implements BackupHistoryService {
+
+  private final BackupHistoryRepository backupHistoryRepository;
+  private final EmployeeRepository employeeRepository;
+  private final BackupHistoryMapper backupHistoryMapper;
+
+  // create
+  @Transactional
+  public BackupHistoryDto create(String worker) {
+    // 백업 필요 여부 판단
+    boolean backupNeeded = isBackupNeeded();
+
+    // 백업 필요 없으면 skipped 상태로 저장 후 종료
+    if (!backupNeeded) {
+      BackupHistory skipped = BackupHistory.ofSkipped(worker);
+      backupHistoryRepository.save(skipped);
+      return backupHistoryMapper.toDto(skipped);
+    } else { //필요하면 IN_PROGRESS 상태로 등록
+      BackupHistory history = BackupHistory.ofInProgress(worker);
+      backupHistoryRepository.save(history);
+      return backupHistoryMapper.toDto(history);
+    }
+  }
+
+  // 백업 필요한지 판단 로직
+  private boolean isBackupNeeded() {
+    Optional<BackupHistory> lastCompleted =
+        backupHistoryRepository.findTopByStatusOrderByStartedAtDesc(BackupStatus.COMPLETED);
+
+    if (lastCompleted.isEmpty()) {
+      return true; // 완료된 백업 이력 자체가 없으면 백업 필요
+    }
+
+    Instant lastBackupTime = lastCompleted.get().getEndedAt();
+    // 마지막 백업 완료된 시간 이후 직원 데이터가 변경됐는지 확인하는 메소드
+    // TODO : employeeRepository 구현체 들어오면 해당 메소드 추가해야됨
+    return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
+  }
+
+  // TODO : 이후 메서드 구현
+}


### PR DESCRIPTION
## 관련 이슈
- closes #21 

## 변경사항
- 기존 Entity는 생성자 방식으로 정의했으나 진행중으로 생성되는 경우와 스킵으로 생성되는 경우가 있어 정적 팩토리 메서드 방식으로 수정 
    - 파라미터를 추가하는 방식으로 하지 않은 이유: Status를 값으로 받는 것보다 생성시 고정하는 것이 안전하다고 판단
- 서비스 레이어: 백업이 필요 없으면 Status를 SKIPPED으로 생성하고 필요하면 IN_PROGRESS로 생성하는 create() 코드 작성
- 백업 판단 로직의 경우 레포지토리에서 findTopByStatusOrderByStartedAtDesc() 메서드를 호출하여 마지막으로 완료된 백업의 끝난 시각을 반환하여 employeeRepository에서 특정 시점 이후로 변경된 직원이 있는지 여부를 확인함. 이에 EmployeeRepository에 existsByUpdatedAtAfter 메서드 추가 작성함
- 연관된 기능이라 생각하여 Controller에 생성 api (POST) 작성해두었으나 추후 수정 예정 


## 테스트
- [x] API 문서(Swagger) 확인

## 스크린샷 (선택)

