### PR TITLE
Feat: 직원 정보 수정 이력 Entity 및 기본 Repository 구현

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/entity/EmployeeAuditHistory.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/EmployeeAuditHistory.java
@@ -1,0 +1,65 @@
+package com.hrbank3.hrbank3.entity;
+
+import com.hrbank3.hrbank3.entity.enums.AuditType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "employee_audit_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class EmployeeAuditHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "audit_type", nullable = false, length = 20)
+  private AuditType auditType;
+
+  @Column(name = "target_employee_no", nullable = false, length = 50)
+  private String targetEmployeeNo;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "changed_content", nullable = false, columnDefinition = "jsonb")
+  private Map<String, Object> changedContent;
+
+  @Column(name = "memo", length = 255)
+  private String memo;
+
+  @Column(name = "ip_address", nullable = false, length = 50)
+  private String ipAddress;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Builder
+  public EmployeeAuditHistory(AuditType auditType, String targetEmployeeNo,
+      Map<String, Object> changedContent, String memo, String ipAddress) {
+    this.auditType = auditType;
+    this.targetEmployeeNo = targetEmployeeNo;
+    this.changedContent = changedContent;
+    this.memo = memo;
+    this.ipAddress = ipAddress;
+  }
+}

--- a/src/main/java/com/hrbank3/hrbank3/entity/enums/AuditType.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/enums/AuditType.java
@@ -1,0 +1,16 @@
+package com.hrbank3.hrbank3.entity.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "이력 유형 Enum")
+public enum AuditType {
+  CREATED("직원 추가"),
+  UPDATED("직원 정보 수정"),
+  DELETED("직원 삭제");
+
+  private final String description;
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.hrbank3.hrbank3.repository;
+
+import com.hrbank3.hrbank3.entity.EmployeeAuditHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeAuditHistoryRepository extends JpaRepository<EmployeeAuditHistory, Long> {
+
+}


### PR DESCRIPTION
## 관련 이슈
- closes #25

## 변경사항
- **`AuditType` Enum 생성 및 enums 패키지 생성**
    - `CREATED`, `UPDATED`, `DELETED` 상태 정의 및 Description 추가
- **`EmployeeAuditHistory` Entity 설계**
    - OOM 방지를 위한 **느슨한 결합** 적용: 직원이 삭제되어도 이력이 보존되도록 `targetEmployeeNo`를 FK로 묶지 않고 String으로 저장
    - **`jsonb` 타입 매핑:** 변경 상세 내용을 담기 위해 `@JdbcTypeCode(SqlTypes.JSON)` 어노테이션을 사용하여 `changedContent` 필드를 `Map<String, Object>` 형태로 생성
- **`EmployeeAuditHistoryRepository` 생성:**
    - 기본적인 CRUD를 위한 JPA Repository 추가

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인

## 스크린샷 (선택)
