### PR TITLE
Refactor: 부서 관련 DTO 패키지 분리 및 CursorPageResponseDto 타입 수정 [#45]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/DepartmentController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DepartmentController.java
@@ -1,10 +1,10 @@
-package com.hrbank.hrbank.controller;
+package com.hrbank3.hrbank3.controller;
 
-import com.hrbank.hrbank.dto.CursorPageResponseDto;
-import com.hrbank.hrbank.dto.DepartmentDto;
-import com.hrbank.hrbank.dto.DepartmentCreateRequest;
-import com.hrbank.hrbank.dto.DepartmentUpdateRequest;
-import com.hrbank.hrbank.service.DepartmentService;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentCreateRequest;
+import com.hrbank3.hrbank3.dto.department.DepartmentUpdateRequest;
+import com.hrbank3.hrbank3.service.DepartmentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/hrbank3/hrbank3/dto/CursorPageResponseDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/CursorPageResponseDto.java
@@ -1,10 +1,10 @@
-package com.hrbank.hrbank.dto;
+package com.hrbank3.hrbank3.dto;
 
 import java.util.List;
 
 public record CursorPageResponseDto<T>(
         List<T> content,      // 실제 데이터 목록
-        Long nextCursor,      // 다음 페이지 시작 기준 ID
+        String nextCursor,      // 다음 페이지 시작 기준 ID
         Long nextIdAfter,     // 다음 페이지 시작 ID
         int size,             // 현재 페이지 데이터 개수
         long totalElements,   // 전체 데이터 개수

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
@@ -1,4 +1,4 @@
-package com.hrbank.hrbank.dto;
+package com.hrbank3.hrbank3.dto.department;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentDto.java
@@ -1,4 +1,4 @@
-package com.hrbank.hrbank.dto;
+package com.hrbank3.hrbank3.dto.department;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.hrbank.hrbank.dto;
+package com.hrbank3.hrbank3.dto.department;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/hrbank3/hrbank3/entity/Department.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/Department.java
@@ -1,4 +1,4 @@
-package com.hrbank.hrbank.entity;
+package com.hrbank3.hrbank3.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepository.java
@@ -1,6 +1,6 @@
-package com.hrbank.hrbank.repository;
+package com.hrbank3.hrbank3.repository;
 
-import com.hrbank.hrbank.entity.Department;
+import com.hrbank3.hrbank3.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryCustom.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryCustom.java
@@ -1,7 +1,7 @@
-package com.hrbank.hrbank.repository;
+package com.hrbank3.hrbank3.repository;
 
-import com.hrbank.hrbank.dto.CursorPageResponseDto;
-import com.hrbank.hrbank.dto.DepartmentDto;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentDto;
 
 public interface DepartmentRepositoryCustom {
 

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -1,9 +1,9 @@
-package com.hrbank.hrbank.repository;
+package com.hrbank3.hrbank3.repository;
 
-import com.hrbank.hrbank.dto.CursorPageResponseDto;
-import com.hrbank.hrbank.dto.DepartmentDto;
-import com.hrbank.hrbank.entity.Department;
-import com.hrbank.hrbank.entity.QDepartment;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentDto;
+import com.hrbank3.hrbank3.entity.Department;
+import com.hrbank3.hrbank3.entity.QDepartment;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -1,17 +1,14 @@
-package com.hrbank.hrbank.service;
+package com.hrbank3.hrbank3.service;
 
-import com.hrbank.hrbank.dto.CursorPageResponseDto;
-import com.hrbank.hrbank.dto.DepartmentDto;
-import com.hrbank.hrbank.dto.DepartmentCreateRequest;
-import com.hrbank.hrbank.dto.DepartmentUpdateRequest;
-import com.hrbank.hrbank.entity.Department;
-import com.hrbank.hrbank.repository.DepartmentRepository;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentDto;
+import com.hrbank3.hrbank3.dto.department.DepartmentCreateRequest;
+import com.hrbank3.hrbank3.dto.department.DepartmentUpdateRequest;
+import com.hrbank3.hrbank3.entity.Department;
+import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/test/java/com/hrbank/hrbank/HrbankApplicationTests.java
+++ b/src/test/java/com/hrbank/hrbank/HrbankApplicationTests.java
@@ -1,4 +1,4 @@
-package com.hrbank.hrbank;
+package com.hrbank3.hrbank3;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 관련 이슈
- closes #45 


## 변경사항
- 부서 관련 DTO를 dto/department 패키지로 분리
- CursorPageResponseDto의 nextCursor 타입 Long → String 수정 (API 명세서 기준)
- hrbank ->hrbank3로 변경
