### PR TITLE
Feat: 대시보드 카드형 요약 정보 API 구현 [#41]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
@@ -1,0 +1,27 @@
+package com.hrbank3.hrbank3.controller;
+
+import com.hrbank3.hrbank3.dto.dashboard.DashboardSummaryDto;
+import com.hrbank3.hrbank3.service.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard", description = "대시보드 API")
+@RestController
+@RequestMapping("/api/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    // 카드형 요약 정보 조회
+    @Operation(summary = "대시보드 요약 정보 조회")
+    @GetMapping("/summary")
+    public ResponseEntity<DashboardSummaryDto> getSummary() {
+        return ResponseEntity.ok(dashboardService.getSummary());
+    }
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/dashboard/DashboardSummaryDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/dashboard/DashboardSummaryDto.java
@@ -1,0 +1,11 @@
+package com.hrbank3.hrbank3.dto.dashboard;
+
+import java.time.Instant;
+
+// 대시보드 카드형 요약 정보 응답 DTO
+public record DashboardSummaryDto(
+        long totalEmployeeCount,
+        long recentAuditCount,
+        long thisMonthHireCount,
+        Instant lastBackupAt
+) {}

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -29,7 +29,7 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
         QDepartment department = QDepartment.department;
         BooleanBuilder builder = new BooleanBuilder();
 
-        // 키워드 필터링 (DB에서 바로 처리)
+        // 키워드 필터링
         if (nameOrDescription != null && !nameOrDescription.isBlank()) {
             builder.and(
                     department.name.containsIgnoreCase(nameOrDescription)
@@ -80,12 +80,14 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
                 ))
                 .collect(Collectors.toList());
 
-        Long nextCursor = hasNext ? results.get(results.size() - 1).getId() : null;
+        // nextCursor는 String, nextIdAfter는 Long
+        String nextCursor = hasNext ? String.valueOf(results.get(results.size() - 1).getId()) : null;
+        Long nextIdAfter = hasNext ? results.get(results.size() - 1).getId() : null;
 
         return new CursorPageResponseDto<>(
                 content,
                 nextCursor,
-                nextCursor,
+                nextIdAfter,
                 content.size(),
                 totalElements,
                 hasNext

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
@@ -1,8 +1,11 @@
 package com.hrbank3.hrbank3.repository;
 
 import com.hrbank3.hrbank3.entity.EmployeeAuditHistory;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmployeeAuditHistoryRepository extends JpaRepository<EmployeeAuditHistory, Long> {
 
+    // 특정 시간 이후 생성된 수정 이력 건수 - 대시보드에서 사용
+    long countByCreatedAtAfter(Instant createdAt);
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -1,7 +1,9 @@
 package com.hrbank3.hrbank3.repository;
 
 import com.hrbank3.hrbank3.entity.Employee;
+import com.hrbank3.hrbank3.entity.EmployeeStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
@@ -11,4 +13,10 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
   // 특정 시간 이후 변경된 직원 존재 여부 - BackupHistoryService에서 사용함
   boolean existsByUpdatedAtAfter(Instant lastBackupTime);
+
+  // 퇴사자 제외한 총 직원 수 - 대시보드에서 사용
+  long countByStatusNot(EmployeeStatus status);
+
+  // 이번달 입사자 수 - 대시보드에서 사용
+  long countByHireDateGreaterThanEqualAndStatus(LocalDate hireDate, EmployeeStatus status);
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
@@ -1,0 +1,61 @@
+package com.hrbank3.hrbank3.service;
+
+import com.hrbank3.hrbank3.dto.dashboard.DashboardSummaryDto;
+import com.hrbank3.hrbank3.entity.enums.BackupStatus;
+import com.hrbank3.hrbank3.entity.EmployeeStatus;
+import com.hrbank3.hrbank3.repository.BackupHistoryRepository;
+import com.hrbank3.hrbank3.repository.EmployeeAuditHistoryRepository;
+import com.hrbank3.hrbank3.repository.EmployeeRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final EmployeeRepository employeeRepository;
+    private final EmployeeAuditHistoryRepository employeeAuditHistoryRepository;
+    private final BackupHistoryRepository backupHistoryRepository;
+
+    // 카드형 요약 정보 4개를 한번에 반환
+    @Transactional(readOnly = true)
+    public DashboardSummaryDto getSummary() {
+        return new DashboardSummaryDto(
+                getTotalEmployeeCount(),
+                getRecentAuditCount(),
+                getThisMonthHireCount(),
+                getLastBackupAt()
+        );
+    }
+
+    // 총 직원 수
+    private long getTotalEmployeeCount() {
+        return employeeRepository.countByStatusNot(EmployeeStatus.RESIGNED);
+    }
+
+    // 최근 일주일 수정 이력 건수
+    private long getRecentAuditCount() {
+        Instant oneWeekAgo = Instant.now().minusSeconds(60 * 60 * 24 * 7);
+        return employeeAuditHistoryRepository.countByCreatedAtAfter(oneWeekAgo);
+    }
+
+    // 이번 달 신규 입사자 수
+    private long getThisMonthHireCount() {
+        LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
+        return employeeRepository.countByHireDateGreaterThanEqualAndStatus(
+                firstDayOfMonth, EmployeeStatus.ACTIVE);
+    }
+
+    // 마지막 백업 시간
+    private Instant getLastBackupAt() {
+        return backupHistoryRepository
+                .findTopByStatusOrderByStartedAtDesc(BackupStatus.COMPLETED)
+                .map(backup -> backup.getEndedAt())
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #41 

## 변경사항
- 대시보드 카드형 요약 정보 API 구현 (GET /api/dashboard/summary)
- 총 직원 수 조회 (퇴사자 제외)
- 최근 일주일 수정 이력 건수 조회
- 이번달 신규 입사자 수 조회
- 마지막 백업 시간 조회
- DepartmentRepositoryImpl nextCursor 타입 Long → String 수정

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인

<img width="793" height="920" alt="image" src="https://github.com/user-attachments/assets/3de59e93-eeaf-4936-8728-7b1f64e2176b" />
