### PR TITLE
Feat: 대시보드 차트형 통계 API 구현 [#42]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
@@ -7,16 +7,19 @@ import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.service.DashboardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Dashboard", description = "대시보드 API")
 @RestController
-@RequestMapping("/api/dashboard")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class DashboardController {
 
@@ -24,28 +27,32 @@ public class DashboardController {
 
     // 카드형 요약 정보 조회
     @Operation(summary = "대시보드 요약 정보 조회")
-    @GetMapping("/summary")
+    @GetMapping("/dashboard/summary")
     public ResponseEntity<DashboardSummaryDto> getSummary() {
         return ResponseEntity.ok(dashboardService.getSummary());
     }
 
-    // 최근 1년 월별 직원수 변동 추이
-    @Operation(summary = "최근 1년 월별 직원수 변동 추이 조회")
-    @GetMapping("/employee-trend")
-    public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend() {
-        return ResponseEntity.ok(dashboardService.getEmployeeTrend());
+    // 직원 수 추이 조회
+    @Operation(summary = "직원 수 추이 조회")
+    @GetMapping("/employees/stats/trend")
+    public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false, defaultValue = "month") String unit
+    ) {
+        return ResponseEntity.ok(dashboardService.getEmployeeTrend(from, to, unit));
     }
 
     // 부서별 직원 분포
     @Operation(summary = "부서별 직원 분포 조회")
-    @GetMapping("/department-distribution")
+    @GetMapping("/dashboard/department-distribution")
     public ResponseEntity<List<DepartmentDistributionDto>> getDepartmentDistribution() {
         return ResponseEntity.ok(dashboardService.getDepartmentDistribution());
     }
 
     // 직무별 직원 분포
     @Operation(summary = "직무별 직원 분포 조회")
-    @GetMapping("/position-distribution")
+    @GetMapping("/dashboard/position-distribution")
     public ResponseEntity<List<PositionDistributionDto>> getPositionDistribution() {
         return ResponseEntity.ok(dashboardService.getPositionDistribution());
     }

--- a/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
@@ -4,6 +4,7 @@ import com.hrbank3.hrbank3.dto.dashboard.DashboardSummaryDto;
 import com.hrbank3.hrbank3.dto.dashboard.DepartmentDistributionDto;
 import com.hrbank3.hrbank3.dto.dashboard.EmployeeTrendDto;
 import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
+import com.hrbank3.hrbank3.entity.enums.TrendUnit;
 import com.hrbank3.hrbank3.service.DashboardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,7 +39,7 @@ public class DashboardController {
     public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
-            @RequestParam(required = false, defaultValue = "month") String unit
+            @RequestParam(required = false, defaultValue = "month") TrendUnit unit
     ) {
         return ResponseEntity.ok(dashboardService.getEmployeeTrend(from, to, unit));
     }

--- a/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DashboardController.java
@@ -1,9 +1,13 @@
 package com.hrbank3.hrbank3.controller;
 
 import com.hrbank3.hrbank3.dto.dashboard.DashboardSummaryDto;
+import com.hrbank3.hrbank3.dto.dashboard.DepartmentDistributionDto;
+import com.hrbank3.hrbank3.dto.dashboard.EmployeeTrendDto;
+import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.service.DashboardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,5 +27,26 @@ public class DashboardController {
     @GetMapping("/summary")
     public ResponseEntity<DashboardSummaryDto> getSummary() {
         return ResponseEntity.ok(dashboardService.getSummary());
+    }
+
+    // 최근 1년 월별 직원수 변동 추이
+    @Operation(summary = "최근 1년 월별 직원수 변동 추이 조회")
+    @GetMapping("/employee-trend")
+    public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend() {
+        return ResponseEntity.ok(dashboardService.getEmployeeTrend());
+    }
+
+    // 부서별 직원 분포
+    @Operation(summary = "부서별 직원 분포 조회")
+    @GetMapping("/department-distribution")
+    public ResponseEntity<List<DepartmentDistributionDto>> getDepartmentDistribution() {
+        return ResponseEntity.ok(dashboardService.getDepartmentDistribution());
+    }
+
+    // 직무별 직원 분포
+    @Operation(summary = "직무별 직원 분포 조회")
+    @GetMapping("/position-distribution")
+    public ResponseEntity<List<PositionDistributionDto>> getPositionDistribution() {
+        return ResponseEntity.ok(dashboardService.getPositionDistribution());
     }
 }

--- a/src/main/java/com/hrbank3/hrbank3/dto/dashboard/DepartmentDistributionDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/dashboard/DepartmentDistributionDto.java
@@ -1,0 +1,8 @@
+package com.hrbank3.hrbank3.dto.dashboard;
+
+// 부서별 직원 분포 응답 DTO
+public record DepartmentDistributionDto(
+        Long departmentId,
+        String departmentName,
+        long employeeCount
+) {}

--- a/src/main/java/com/hrbank3/hrbank3/dto/dashboard/EmployeeTrendDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/dashboard/EmployeeTrendDto.java
@@ -1,7 +1,9 @@
 package com.hrbank3.hrbank3.dto.dashboard;
 
-// 최근 1년 월별 직원수 변동 추이 응답 DTO
+// 직원 수 추이 응답 DTO
 public record EmployeeTrendDto(
-        String yearMonth,
-        long employeeCount
+        String date,
+        long count,
+        long change,
+        double changeRate
 ) {}

--- a/src/main/java/com/hrbank3/hrbank3/dto/dashboard/EmployeeTrendDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/dashboard/EmployeeTrendDto.java
@@ -1,0 +1,7 @@
+package com.hrbank3.hrbank3.dto.dashboard;
+
+// 최근 1년 월별 직원수 변동 추이 응답 DTO
+public record EmployeeTrendDto(
+        String yearMonth,
+        long employeeCount
+) {}

--- a/src/main/java/com/hrbank3/hrbank3/dto/dashboard/PositionDistributionDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/dashboard/PositionDistributionDto.java
@@ -1,0 +1,7 @@
+package com.hrbank3.hrbank3.dto.dashboard;
+
+// 직무별 직원 분포 응답 DTO
+public record PositionDistributionDto(
+        String positionName,
+        long employeeCount
+) {}

--- a/src/main/java/com/hrbank3/hrbank3/entity/enums/TrendUnit.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/enums/TrendUnit.java
@@ -1,0 +1,6 @@
+package com.hrbank3.hrbank3.entity.enums;
+
+// 직원 수 추이 조회 시간 단위
+public enum TrendUnit {
+    day, week, month, quarter, year
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepository.java
@@ -1,13 +1,22 @@
 package com.hrbank3.hrbank3.repository;
 
+import com.hrbank3.hrbank3.dto.dashboard.DepartmentDistributionDto;
 import com.hrbank3.hrbank3.entity.Department;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DepartmentRepository extends JpaRepository<Department, Long>,
-        DepartmentRepositoryCustom { // 추가
+        DepartmentRepositoryCustom {
 
     boolean existsByName(String name);
     boolean existsByNameAndIdNot(String name, Long id);
+
+    // 부서별 직원 분포 - 직원 수 기준 내림차순
+    @Query("SELECT new com.hrbank3.hrbank3.dto.dashboard.DepartmentDistributionDto(d.id, d.name, COUNT(e)) " +
+            "FROM Department d LEFT JOIN Employee e ON e.departmentId = d.id AND e.status != 'RESIGNED' " +
+            "GROUP BY d.id, d.name ORDER BY COUNT(e) DESC")
+    List<DepartmentDistributionDto> findAllWithEmployeeCount();
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -1,22 +1,33 @@
 package com.hrbank3.hrbank3.repository;
 
+import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.entity.Employee;
 import com.hrbank3.hrbank3.entity.EmployeeStatus;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
   // 기본적인 CRUD는 JpaRepository가 기본 제공함
   boolean existsByEmail(String email);
 
-  // 특정 시간 이후 변경된 직원 존재 여부 - BackupHistoryService에서 사용함
+  // 특정 시간 이후 변경된 직원 존재 여부
   boolean existsByUpdatedAtAfter(Instant lastBackupTime);
 
-  // 퇴사자 제외한 총 직원 수 - 대시보드에서 사용
+  // 퇴사자 제외한 총 직원 수
   long countByStatusNot(EmployeeStatus status);
 
-  // 이번달 입사자 수 - 대시보드에서 사용
+  // 이번달 입사자 수
   long countByHireDateGreaterThanEqualAndStatus(LocalDate hireDate, EmployeeStatus status);
+
+  // 월별 직원수 추이 - 해당 월 말일 기준 퇴사자 제외 직원 수
+  long countByHireDateLessThanEqualAndStatusNot(LocalDate hireDate, EmployeeStatus status);
+
+  // 직무별 직원 분포
+  @Query("SELECT new com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto(e.position, COUNT(e)) " +
+          "FROM Employee e WHERE e.status != 'RESIGNED' GROUP BY e.position ORDER BY COUNT(e) DESC")
+  List<PositionDistributionDto> findPositionDistribution();
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
@@ -6,6 +6,7 @@ import com.hrbank3.hrbank3.dto.dashboard.EmployeeTrendDto;
 import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.entity.enums.BackupStatus;
 import com.hrbank3.hrbank3.entity.EmployeeStatus;
+import com.hrbank3.hrbank3.entity.enums.TrendUnit;
 import com.hrbank3.hrbank3.repository.BackupHistoryRepository;
 import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import com.hrbank3.hrbank3.repository.EmployeeAuditHistoryRepository;
@@ -43,10 +44,10 @@ public class DashboardService {
 
     // 직원 수 추이 조회 (from, to, unit 파라미터)
     @Transactional(readOnly = true)
-    public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit) {
+    public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, TrendUnit unit) {
         // 기본값 설정
-        if (unit == null || unit.isBlank()) {
-            unit = "month";
+        if (unit == null) {
+            unit = TrendUnit.month;
         }
         if (to == null) {
             to = LocalDate.now();
@@ -127,57 +128,56 @@ public class DashboardService {
     }
 
     // unit 기준 기본 시작일 계산
-    private LocalDate getDefaultFrom(LocalDate to, String unit) {
+    private LocalDate getDefaultFrom(LocalDate to, TrendUnit unit) {
         return switch (unit) {
-            case "day" -> to.minusDays(11);
-            case "week" -> to.minusWeeks(11);
-            case "quarter" -> to.minusMonths(33);
-            case "year" -> to.minusYears(11);
-            default -> to.minusMonths(11); // month
+            case day -> to.minusDays(11);
+            case week -> to.minusWeeks(11);
+            case quarter -> to.minusMonths(33);
+            case year -> to.minusYears(11);
+            default -> to.minusMonths(11);
         };
     }
 
     // 해당 기간의 마지막 날 계산
-    private LocalDate getPeriodEnd(LocalDate start, String unit, LocalDate max) {
+    private LocalDate getPeriodEnd(LocalDate start, TrendUnit unit, LocalDate max) {
         LocalDate end = switch (unit) {
-            case "day" -> start;
-            case "week" -> start.plusWeeks(1).minusDays(1);
-            case "quarter" -> start.plusMonths(3).minusDays(1);
-            case "year" -> start.plusYears(1).minusDays(1);
-            default -> start.withDayOfMonth(start.lengthOfMonth()); // month
+            case day -> start;
+            case week -> start.plusWeeks(1).minusDays(1);
+            case quarter -> start.plusMonths(3).minusDays(1);
+            case year -> start.plusYears(1).minusDays(1);
+            default -> start.withDayOfMonth(start.lengthOfMonth());
         };
         return end.isAfter(max) ? max : end;
     }
 
     // 다음 기간 시작일 계산
-    private LocalDate getNextPeriodStart(LocalDate current, String unit) {
+    private LocalDate getNextPeriodStart(LocalDate current, TrendUnit unit) {
         return switch (unit) {
-            case "day" -> current.plusDays(1);
-            case "week" -> current.plusWeeks(1);
-            case "quarter" -> current.plusMonths(3);
-            case "year" -> current.plusYears(1);
-            default -> current.plusMonths(1); // month
+            case day -> current.plusDays(1);
+            case week -> current.plusWeeks(1);
+            case quarter -> current.plusMonths(3);
+            case year -> current.plusYears(1);
+            default -> current.plusMonths(1);
         };
     }
 
     // 이전 기간 시작일 계산
-    private LocalDate getPrevPeriodStart(LocalDate current, String unit) {
+    private LocalDate getPrevPeriodStart(LocalDate current, TrendUnit unit) {
         return switch (unit) {
-            case "day" -> current.minusDays(1);
-            case "week" -> current.minusWeeks(1);
-            case "quarter" -> current.minusMonths(3);
-            case "year" -> current.minusYears(1);
-            default -> current.minusMonths(1); // month
+            case day -> current.minusDays(1);
+            case week -> current.minusWeeks(1);
+            case quarter -> current.minusMonths(3);
+            case year -> current.minusYears(1);
+            default -> current.minusMonths(1);
         };
     }
 
     // unit별 날짜 포맷
-    private DateTimeFormatter getFormatter(String unit) {
+    private DateTimeFormatter getFormatter(TrendUnit unit) {
         return switch (unit) {
-            case "day", "week" -> DateTimeFormatter.ofPattern("yyyy-MM-dd");
-            case "year" -> DateTimeFormatter.ofPattern("yyyy");
-            case "quarter" -> DateTimeFormatter.ofPattern("yyyy-MM");
-            default -> DateTimeFormatter.ofPattern("yyyy-MM"); // month
+            case day, week -> DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            case year -> DateTimeFormatter.ofPattern("yyyy");
+            default -> DateTimeFormatter.ofPattern("yyyy-MM");
         };
     }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
@@ -41,23 +41,49 @@ public class DashboardService {
         );
     }
 
-    // 최근 1년 월별 직원수 변동 추이
+    // 직원 수 추이 조회 (from, to, unit 파라미터)
     @Transactional(readOnly = true)
-    public List<EmployeeTrendDto> getEmployeeTrend() {
+    public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit) {
+        // 기본값 설정
+        if (unit == null || unit.isBlank()) {
+            unit = "month";
+        }
+        if (to == null) {
+            to = LocalDate.now();
+        }
+        if (from == null) {
+            from = getDefaultFrom(to, unit);
+        }
+
         List<EmployeeTrendDto> trend = new ArrayList<>();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
-        LocalDate now = LocalDate.now();
+        LocalDate cursor = from;
 
-        for (int i = 11; i >= 0; i--) {
-            // 해당 월의 마지막 날 기준으로 직원 수 계산
-            LocalDate targetMonth = now.minusMonths(i);
-            LocalDate lastDayOfMonth = targetMonth.withDayOfMonth(targetMonth.lengthOfMonth());
+        while (!cursor.isAfter(to)) {
+            LocalDate periodEnd = getPeriodEnd(cursor, unit, to);
 
-            // 해당 월 말일 기준으로 입사한 재직/휴직 직원 수
+            // 해당 기간 말일 기준 재직/휴직 직원 수
             long count = employeeRepository.countByHireDateLessThanEqualAndStatusNot(
-                    lastDayOfMonth, EmployeeStatus.RESIGNED);
+                    periodEnd, EmployeeStatus.RESIGNED);
 
-            trend.add(new EmployeeTrendDto(targetMonth.format(formatter), count));
+            // 이전 기간 직원 수
+            LocalDate prevPeriodEnd = getPeriodEnd(getPrevPeriodStart(cursor, unit), unit,
+                    cursor.minusDays(1));
+            long prevCount = employeeRepository.countByHireDateLessThanEqualAndStatusNot(
+                    prevPeriodEnd, EmployeeStatus.RESIGNED);
+
+            // 증감 수, 증감률 계산
+            long change = count - prevCount;
+            double changeRate = prevCount == 0 ? 0.0
+                    : Math.round((double) change / prevCount * 1000) / 10.0;
+
+            trend.add(new EmployeeTrendDto(
+                    cursor.format(getFormatter(unit)),
+                    count,
+                    change,
+                    changeRate
+            ));
+
+            cursor = getNextPeriodStart(cursor, unit);
         }
         return trend;
     }
@@ -98,5 +124,60 @@ public class DashboardService {
                 .findTopByStatusOrderByStartedAtDesc(BackupStatus.COMPLETED)
                 .map(backup -> backup.getEndedAt())
                 .orElse(null);
+    }
+
+    // unit 기준 기본 시작일 계산
+    private LocalDate getDefaultFrom(LocalDate to, String unit) {
+        return switch (unit) {
+            case "day" -> to.minusDays(11);
+            case "week" -> to.minusWeeks(11);
+            case "quarter" -> to.minusMonths(33);
+            case "year" -> to.minusYears(11);
+            default -> to.minusMonths(11); // month
+        };
+    }
+
+    // 해당 기간의 마지막 날 계산
+    private LocalDate getPeriodEnd(LocalDate start, String unit, LocalDate max) {
+        LocalDate end = switch (unit) {
+            case "day" -> start;
+            case "week" -> start.plusWeeks(1).minusDays(1);
+            case "quarter" -> start.plusMonths(3).minusDays(1);
+            case "year" -> start.plusYears(1).minusDays(1);
+            default -> start.withDayOfMonth(start.lengthOfMonth()); // month
+        };
+        return end.isAfter(max) ? max : end;
+    }
+
+    // 다음 기간 시작일 계산
+    private LocalDate getNextPeriodStart(LocalDate current, String unit) {
+        return switch (unit) {
+            case "day" -> current.plusDays(1);
+            case "week" -> current.plusWeeks(1);
+            case "quarter" -> current.plusMonths(3);
+            case "year" -> current.plusYears(1);
+            default -> current.plusMonths(1); // month
+        };
+    }
+
+    // 이전 기간 시작일 계산
+    private LocalDate getPrevPeriodStart(LocalDate current, String unit) {
+        return switch (unit) {
+            case "day" -> current.minusDays(1);
+            case "week" -> current.minusWeeks(1);
+            case "quarter" -> current.minusMonths(3);
+            case "year" -> current.minusYears(1);
+            default -> current.minusMonths(1); // month
+        };
+    }
+
+    // unit별 날짜 포맷
+    private DateTimeFormatter getFormatter(String unit) {
+        return switch (unit) {
+            case "day", "week" -> DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            case "year" -> DateTimeFormatter.ofPattern("yyyy");
+            case "quarter" -> DateTimeFormatter.ofPattern("yyyy-MM");
+            default -> DateTimeFormatter.ofPattern("yyyy-MM"); // month
+        };
     }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DashboardService.java
@@ -1,13 +1,20 @@
 package com.hrbank3.hrbank3.service;
 
 import com.hrbank3.hrbank3.dto.dashboard.DashboardSummaryDto;
+import com.hrbank3.hrbank3.dto.dashboard.DepartmentDistributionDto;
+import com.hrbank3.hrbank3.dto.dashboard.EmployeeTrendDto;
+import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.entity.enums.BackupStatus;
 import com.hrbank3.hrbank3.entity.EmployeeStatus;
 import com.hrbank3.hrbank3.repository.BackupHistoryRepository;
+import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import com.hrbank3.hrbank3.repository.EmployeeAuditHistoryRepository;
 import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,6 +28,7 @@ public class DashboardService {
     private final EmployeeRepository employeeRepository;
     private final EmployeeAuditHistoryRepository employeeAuditHistoryRepository;
     private final BackupHistoryRepository backupHistoryRepository;
+    private final DepartmentRepository departmentRepository;
 
     // 카드형 요약 정보 4개를 한번에 반환
     @Transactional(readOnly = true)
@@ -33,7 +41,40 @@ public class DashboardService {
         );
     }
 
-    // 총 직원 수
+    // 최근 1년 월별 직원수 변동 추이
+    @Transactional(readOnly = true)
+    public List<EmployeeTrendDto> getEmployeeTrend() {
+        List<EmployeeTrendDto> trend = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        LocalDate now = LocalDate.now();
+
+        for (int i = 11; i >= 0; i--) {
+            // 해당 월의 마지막 날 기준으로 직원 수 계산
+            LocalDate targetMonth = now.minusMonths(i);
+            LocalDate lastDayOfMonth = targetMonth.withDayOfMonth(targetMonth.lengthOfMonth());
+
+            // 해당 월 말일 기준으로 입사한 재직/휴직 직원 수
+            long count = employeeRepository.countByHireDateLessThanEqualAndStatusNot(
+                    lastDayOfMonth, EmployeeStatus.RESIGNED);
+
+            trend.add(new EmployeeTrendDto(targetMonth.format(formatter), count));
+        }
+        return trend;
+    }
+
+    // 부서별 직원 분포
+    @Transactional(readOnly = true)
+    public List<DepartmentDistributionDto> getDepartmentDistribution() {
+        return departmentRepository.findAllWithEmployeeCount();
+    }
+
+    // 직무별 직원 분포
+    @Transactional(readOnly = true)
+    public List<PositionDistributionDto> getPositionDistribution() {
+        return employeeRepository.findPositionDistribution();
+    }
+
+    // 총 직원 수 (퇴사자 제외)
     private long getTotalEmployeeCount() {
         return employeeRepository.countByStatusNot(EmployeeStatus.RESIGNED);
     }


### PR DESCRIPTION
## 관련 이슈
- closes #42 

## 변경사항
- 직원 수 추이 조회 API 구현 (GET /api/employees/stats/trend)
  - from, to, unit 파라미터 지원 (day, week, month, quarter, year)
  - 파라미터 미입력 시 기본값: 최근 12개월, month 단위
  - date, count, change, changeRate 응답
- 부서별 직원 분포 API 구현 (GET /api/dashboard/department-distribution)
- 직무별 직원 분포 API 구현 (GET /api/dashboard/position-distribution)
- DepartmentRepository에 부서별 직원 수 집계 쿼리 추가
- EmployeeRepository에 월별 직원수 추이 및 직무별 분포 쿼리 추가

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인
<img width="910" height="320" alt="대시보드" src="https://github.com/user-attachments/assets/d14ffa95-0463-467d-ac25-7ea81af46866" />
