### PR TITLE
Feat: DB 인덱스 설계를 통한 조회 쿼리 최적화[#37]

### DIFF
--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS departments (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
+CREATE INDEX idx_department_name ON departments (name);
+CREATE INDEX idx_department_desc ON departments (description);
 
 -- 2. files 테이블 생성
 CREATE TABLE IF NOT EXISTS files (
@@ -35,6 +37,12 @@ CREATE TABLE IF NOT EXISTS employees (
     CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments(id),
     CONSTRAINT fk_profile_image FOREIGN KEY (profile_image_id) REFERENCES files(id)
 );
+CREATE INDEX idx_emp_name ON employees (name);
+CREATE INDEX idx_emp_email ON employees (email);
+CREATE INDEX idx_emp_department ON employees (department_id);
+CREATE INDEX idx_emp_position ON employees (position);
+CREATE INDEX idx_employ_number ON employees (employee_number);
+CREATE INDEX idx_emp_status_hire_date ON employees (status, hire_date DESC);
 
 -- 4. employee_audit_histories 테이블 생성
 CREATE TABLE IF NOT EXISTS employee_audit_histories (
@@ -46,6 +54,10 @@ CREATE TABLE IF NOT EXISTS employee_audit_histories (
     ip_address VARCHAR(50) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
+CREATE INDEX idx_target_employee_no ON employee_audit_histories (target_employee_no);
+CREATE INDEX idx_memo ON employee_audit_histories (memo);
+CREATE INDEX idx_ip_address ON employee_audit_histories (ip_address);
+CREATE INDEX idx_audit_type_created_at ON employee_audit_histories (audit_type, created_at DESC);
 
 -- 5. backup_histories 테이블 생성
 CREATE TABLE IF NOT EXISTS backup_histories (
@@ -57,3 +69,5 @@ CREATE TABLE IF NOT EXISTS backup_histories (
     file_id BIGINT,
     CONSTRAINT fk_backup_file FOREIGN KEY (file_id) REFERENCES files(id)
 );
+CREATE INDEX idx_backup_histories_status_started_at ON backup_histories (status, started_at DESC);
+CREATE INDEX idx_worker ON backup_histories (worker);

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 -- 1. departments 테이블 생성
 CREATE TABLE IF NOT EXISTS departments (
     id BIGSERIAL PRIMARY KEY,
@@ -7,6 +9,8 @@ CREATE TABLE IF NOT EXISTS departments (
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL
 );
+-- 이름 또는 설명 (부분 일치 조건으로 인덱스 생성)
+CREATE INDEX idx_department_name_desc ON departments USING gin(name gin_trgm_ops, description gin_trgm_ops);
 
 -- 2. files 테이블 생성
 CREATE TABLE IF NOT EXISTS files (
@@ -35,6 +39,16 @@ CREATE TABLE IF NOT EXISTS employees (
     CONSTRAINT fk_department FOREIGN KEY (department_id) REFERENCES departments(id),
     CONSTRAINT fk_profile_image FOREIGN KEY (profile_image_id) REFERENCES files(id)
 );
+-- 이름 또는 이메일 (부분 일치 조건으로 인덱스 생성)
+CREATE INDEX idx_name_email ON employees USING  gin(name gin_trgm_ops, email gin_trgm_ops);
+-- 부서ID (부서명 검색 시 departments 테이블과 빠른 조인을 위하여 일반 인덱스 사용)
+CREATE INDEX idx_emp_department_id On employees (department_id);
+-- 직함 (부분 일치)
+CREATE INDEX idx_position ON employees USING gin(position gin_trgm_ops);
+-- 사원번호 (부분 일치)
+CREATE INDEX idx_employee_number ON employees USING gin(employee_number gin_trgm_ops);
+-- 상태 및 입사일 (완전 일치인 상태를 앞에 두어 상태를 기준으로 먼저 정렬 후 입사일 범위 조건)
+CREATE INDEX idx_status_hire_date ON employees (status, hire_date DESC);
 
 -- 4. employee_audit_histories 테이블 생성
 CREATE TABLE IF NOT EXISTS employee_audit_histories (
@@ -46,6 +60,14 @@ CREATE TABLE IF NOT EXISTS employee_audit_histories (
     ip_address VARCHAR(50) NOT NULL,
     created_at TIMESTAMPTZ NOT NULL
 );
+-- 대상 직원 사번 (부분 일치)
+CREATE INDEX idx_target_employee_no ON employee_audit_histories USING gin(target_employee_no gin_trgm_ops);
+-- 메모 (부분 일치)
+CREATE INDEX idx_memo ON employee_audit_histories USING gin(memo gin_trgm_ops);
+-- IP주소 (부분 일치)
+CREATE INDEX idx_ip_address ON employee_audit_histories USING gin(ip_address gin_trgm_ops);
+-- 유형 및 시간 (완전 일치인 유형을 앞에 두어 유형을 기준으로 먼저 정렬 후 시간 범위 조건)
+CREATE INDEX idx_audit_type_created_at ON employee_audit_histories (audit_type, created_at DESC);
 
 -- 5. backup_histories 테이블 생성
 CREATE TABLE IF NOT EXISTS backup_histories (
@@ -57,3 +79,7 @@ CREATE TABLE IF NOT EXISTS backup_histories (
     file_id BIGINT,
     CONSTRAINT fk_backup_file FOREIGN KEY (file_id) REFERENCES files(id)
 );
+-- 상태 및 시작 시간
+CREATE INDEX idx_backup_histories_status_started_at ON backup_histories (status, started_at DESC);
+-- 작업자 (부분 일치)
+CREATE INDEX idx_worker ON backup_histories USING gin(worker gin_trgm_ops);


### PR DESCRIPTION
## 관련 이슈
- closes #37 

## 변경사항
- HR Bank안내에 나와있는 내용에 따라 인덱스를 작성하여 추가하였습니다.
- schema-postgres.sql은 GIN 인덱스와 B-Tree 인덱스를 사용하였습니다.
  - 부분 일치 조건 : GIN 인덱스 사용
  - 범위 일치, 완전 일치 : B-Tree 인덱스 사용
- schema-h2.sql은 B-Tree 인덱스를 사용하였습니다.

## 테스트
- [x] 로컬 테스트 완료

---
## 코드리뷰 요청사항
### 요청 1
- **파일/위치**: `src/main/resources/schema-postgres.sql`
- **요청 내용**: 현재 부분 일치 검색 인덱스를 GIN 인덱스를 사용하여 구현했는데, 더 나은 방식이 있을지 궁금합니다.
- **고민한 점**: 긴 문장이나 배열을 여러 조각으로 쪼개서 각각의 위치를 기록 한다는 점에서 GIN인덱스를 부분 검색의 인덱스로 사용해야겠다는 고민을 했습니다.


## 스크린샷 (선택)
