### PR TITLE
Feat: 전역 예외 처리 핸들러 추가 [#50]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hrbank3/hrbank3/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.hrbank3.hrbank3.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,30 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
   /// 개발 중 발생하는 에러 핸들링 추가
+
+  // 400 BadRequest
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+      IllegalArgumentException e, HttpServletRequest request) {
+    ErrorResponse response = ErrorResponse.of(
+        HttpStatus.BAD_REQUEST.value(),
+        e.getMessage(),
+        request.getRequestURI()
+    );
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  // 404 Not Found
+  @ExceptionHandler(NoSuchElementException.class)
+  public ResponseEntity<ErrorResponse> handleNoSuchElementException(
+      NoSuchElementException e, HttpServletRequest request) {
+    ErrorResponse response = ErrorResponse.of(
+        HttpStatus.NOT_FOUND.value(),
+        e.getMessage(),
+        request.getRequestURI()
+    );
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+  }
 
   // 나머지 모든 서버 에러 500 Internal Server Error
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
@@ -7,6 +7,8 @@ import com.hrbank3.hrbank3.dto.employee.EmployeeUpdateRequest;
 import com.hrbank3.hrbank3.entity.enums.EmployeeStatus;
 import com.hrbank3.hrbank3.repository.condition.EmployeeSearchCondition;
 import com.hrbank3.hrbank3.service.EmployeeService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ public class EmployeeController {
   //employee 객체와 profile 파일 같이 보내야하는데, 파일이 포함된 요청은 multipart/form-data 써야함
   public ResponseEntity<EmployeeDto> create(
       @RequestPart(value = "employee")
+      @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
       @Valid EmployeeCreateRequest request,
       @RequestPart(value = "profile", required = false) MultipartFile profile
   ) {


### PR DESCRIPTION
## 관련 이슈
- closes #50

## 변경사항
- GlobalExceptionHandler에 비즈니스 로직 예외 핸들러 추가했습니다.
  - IllegalArgumentException → 400 Bad Request 처리
  - NoSuchElementException → 404 Not Found 처리
- Swagger에서 employee 파트 Content-Type이 application/octet-stream으로 설정되는 문제를 수정했습니다.
  - @Parameter(content = @Content(mediaType = ...)) 어노테이션 추가

## 테스트
- [x] 로컬 테스트 완료
  - 중복 이메일 등록 시 400 응답 확인
  - 존재하지 않는 ID 조회 시 404 응답 확인
- [x] API 문서(Swagger) 확인

<img width="911" height="587" alt="스크린샷 2026-04-18 오후 5 43 03" src="https://github.com/user-attachments/assets/a9ea2b49-ab5e-4d17-ae86-321c73a070f6" />
<img width="911" height="587" alt="스크린샷 2026-04-18 오후 5 43 34" src="https://github.com/user-attachments/assets/97f15ea0-4994-47e7-91a7-3f6ad4342d67" />
<img width="911" height="587" alt="스크린샷 2026-04-18 오후 5 54 14" src="https://github.com/user-attachments/assets/d5d99009-1989-408b-bd75-22df8e6ba23a" />
<img width="911" height="587" alt="스크린샷 2026-04-18 오후 6 06 07" src="https://github.com/user-attachments/assets/2114a9b6-c96f-4250-8167-54b5b003a958" />
