### PR TITLE
Feat: 직원 수정 이력 상세 내용 조회 API 구현

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
@@ -1,0 +1,46 @@
+package com.hrbank3.hrbank3.controller;
+
+import com.hrbank3.hrbank3.common.exception.ErrorResponse;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDetailDto;
+import com.hrbank3.hrbank3.service.EmployeeAuditHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "직원 정보 수정 이력 관리", description = "직원 정보 수정 이력 관리 API")
+@RestController
+@RequestMapping("/api/change-logs")
+@RequiredArgsConstructor
+public class EmployeeAuditHistoryController {
+
+  private final EmployeeAuditHistoryService auditHistoryService;
+
+  @Operation(summary = "직원 정보 수정 이력 상세 조회", description = "특정 수정 이력의 상세 변경 내역을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(
+          responseCode = "404",
+          description = "이력을 찾을 수 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "서버 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      )
+  })
+  @GetMapping("/{id}")
+  public ResponseEntity<ChangeLogDetailDto> getChangeLogDetail(@PathVariable("id") Long id) {
+    ChangeLogDetailDto detailDto = auditHistoryService.getAuditDetail(id);
+    return ResponseEntity.ok(detailDto);
+  }
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/audit_history/ChangeLogDetailDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/audit_history/ChangeLogDetailDto.java
@@ -1,0 +1,18 @@
+package com.hrbank3.hrbank3.dto.audit_history;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ChangeLogDetailDto(
+    Long id,
+    String type,
+    String employeeNumber,
+    String memo,
+    String ipAddress,
+    Instant at,
+    String employeeName,
+    Long profileImageId,
+    List<DiffDto> diffs
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/audit_history/DiffDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/audit_history/DiffDto.java
@@ -1,0 +1,9 @@
+package com.hrbank3.hrbank3.dto.audit_history;
+
+public record DiffDto(
+    String propertyName,
+    String before,
+    String after
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -2,11 +2,12 @@ package com.hrbank3.hrbank3.repository;
 
 import com.hrbank3.hrbank3.dto.dashboard.PositionDistributionDto;
 import com.hrbank3.hrbank3.entity.Employee;
-import com.hrbank3.hrbank3.repository.custom.EmployeeRepositoryCustom;
 import com.hrbank3.hrbank3.entity.enums.EmployeeStatus;
+import com.hrbank3.hrbank3.repository.custom.EmployeeRepositoryCustom;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +18,8 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
 
   // 기본적인 CRUD는 JpaRepository가 기본 제공함
   boolean existsByEmail(String email);
+
+  Optional<Employee> findByEmployeeNumber(String employeeNumber);
 
   // 특정 시간 이후 변경된 직원 존재 여부
   boolean existsByUpdatedAtAfter(Instant lastBackupTime);

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -1,12 +1,16 @@
 package com.hrbank3.hrbank3.service;
 
 import com.hrbank3.hrbank3.common.util.IpExtractUtil;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDetailDto;
+import com.hrbank3.hrbank3.dto.audit_history.DiffDto;
 import com.hrbank3.hrbank3.entity.EmployeeAuditHistory;
 import com.hrbank3.hrbank3.entity.enums.AuditType;
 import com.hrbank3.hrbank3.event.EmployeeAuditEvent;
 import com.hrbank3.hrbank3.repository.EmployeeAuditHistoryRepository;
+import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -20,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmployeeAuditHistoryService {
 
   private final EmployeeAuditHistoryRepository auditRepository;
+  private final EmployeeRepository employeeRepository;
+
 
   // 직원 정보 수정 시 발생하는 핸들링
   @Transactional
@@ -64,5 +70,74 @@ public class EmployeeAuditHistoryService {
       }
     }
     return diffMap;
+  }
+
+  // 상세 데이터 읽기
+  @Transactional(readOnly = true)
+  public ChangeLogDetailDto getAuditDetail(Long id) {
+    EmployeeAuditHistory audit = auditRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
+
+    List<DiffDto> diffs = audit.getChangedContent().entrySet().stream()
+        .map(entry -> {
+          Map<String, Object> values = (Map<String, Object>) entry.getValue();
+          return new DiffDto(
+              entry.getKey(),
+              String.valueOf(values.get("before")),
+              String.valueOf(values.get("after"))
+          );
+        })
+        .toList();
+
+    EmployeeInfo info = resolveEmployeeInfo(audit, diffs);
+
+    return new ChangeLogDetailDto(
+        audit.getId(),
+        audit.getAuditType().name(),
+        audit.getTargetEmployeeNo(),
+        audit.getMemo(),
+        audit.getIpAddress(),
+        audit.getCreatedAt(),
+        info.name(),
+        info.profileImageId(),
+        diffs
+    );
+  }
+
+  // 사원 이름 및
+  private EmployeeInfo resolveEmployeeInfo(EmployeeAuditHistory audit, List<DiffDto> diffs) {
+    return employeeRepository.findByEmployeeNumber(audit.getTargetEmployeeNo())
+        .map(e -> new EmployeeInfo(
+            e.getName(),
+            e.getProfileImage() != null ? e.getProfileImage().getId() : null
+        ))
+        .orElseGet(() -> {
+          String deletedName = diffs.stream()
+              .filter(d -> "name".equals(d.propertyName()))
+              .map(DiffDto::before)
+              .findFirst()
+              .orElse("알 수 없음");
+
+          Long deletedProfileId = diffs.stream()
+              .filter(d -> "profileImageId".equals(d.propertyName()))
+              .map(DiffDto::before)
+              .filter(val -> val != null && !"-".equals(val) && !"null".equals(val)) // 파싱 에러 방지
+              .map(val -> {
+                try {
+                  return Long.parseLong(val);
+                } catch (NumberFormatException ex) {
+                  return null;
+                }
+              })
+              .filter(Objects::nonNull)
+              .findFirst()
+              .orElse(null);
+          return new EmployeeInfo(deletedName, deletedProfileId);
+        });
+  }
+
+  // 데이터 전달용 임시 레코드
+  private record EmployeeInfo(String name, Long profileImageId) {
+
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -80,7 +80,10 @@ public class EmployeeAuditHistoryService {
 
     List<DiffDto> diffs = audit.getChangedContent().entrySet().stream()
         .map(entry -> {
-          Map<String, Object> values = (Map<String, Object>) entry.getValue();
+          if (!(entry.getValue() instanceof Map<?, ?> values)) {
+            return new DiffDto(entry.getKey(), "-", "-");
+          }
+
           return new DiffDto(
               entry.getKey(),
               String.valueOf(values.get("before")),


### PR DESCRIPTION
## 관련 이슈
- closes #27 

## 📋 PR 기본 정보
프로젝트: 초급
주차: 12주차
PR 요약: 직원 정보 수정 이력 상세 조회 API 구현 및 삭제 직원 정보 복원 로직 추가

---

## 🛠️ 구현 내용
현재는 직원 정보 수정 이력의 상세 내역을 단건으로 조회하는 API와, 영구 삭제된 직원의 필수 정보(이름, 프로필 사진)를 JSON 스냅샷에서 안전하게 복원하는 방어 로직을 구현한 상태입니다.
추후 #29 이슈에서 삭제 이벤트를 발행할 때 beforeData에 해당 필수 값들이 포함되도록 구현할 예정입니다.

- [x] 이력 상세 조회 및 프론트엔드 연동 규격에 맞춘 응답 객체 `ChangeLogDetailDto`, `DiffDto` 추가
    - [x] 엔티티의` Map<String, Object>` 를 프론트엔드 연동이 용이한 리스트 형태의 `ChangeLogDetailDto` 및 `DiffDto`로 가공하여 응답 
- [x] `EmployeeAuditHistoryController`에 `GET /api/change-logs/{id} `상세 조회 엔드포인트 구현
- [x] 삭제된 직원의 식별 불가 문제를 해결하기 위해, DB 대신 `changedContent` JSON 스냅샷에서 name, profileImageId를 추출해 내는 `resolveEmployeeInfo` 복원 로직 구현
- [x] Swagger(OpenAPI) 명세에 404, 500 에러 발생 시 공통 `ErrorResponse` 규격으로 응답됨을 명시

---

## 🔍 코드리뷰 요청 사항
### 요청 1: 삭제된 직원 정보의 복원
- **파일/위치**: `src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java` 내 `resolveEmployeeInfo()` 메서드
- **요청 내용**:  삭제 이벤트를 발행할 때 `beforeData`에 해당 필수 값(이름, 프로필 사진)들이 포함되도록 구현할 예정인데, 직원이 삭제되었을 때 `changedContent` 스냅샷의 `before` 데이터를 통해 이름을 찾아내는 방식이 적절한지 리뷰 부탁드립니다.
- **고민한 점**: 만약 삭제된 직원의 이름이 `changedContent` 내에도 포함되어 있지 않은 상황을 대비해 "알 수 없음"으로 기본값을 설정했는데, 실무에서는 어떻게 처리하는 지 궁금합니다. 또, 삭제 이벤트 발행 당시에 이름, 프로필 사진을 테이블에 컬럼으로 저장하는 방법도 있는 것 같은데 이러한 방법은 어떨지 의견 여쭙고 싶습니다.

### 요청 2: 전반적인 이벤트 핸들링 로직 흐름
- **파일/위치**: `src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java`
- **요청 내용**:  직원 정보 수정 발생 시 이벤트를 발행하고, 해당 이벤를 핸들링하여 넘어온 이벤트 객체를 통해 수정 내용을 조회하는 비즈니스 로직의 흐름이 잘 처리되어 있는지 궁금합니다.
- **고민한 점**: 이 방법 말고 고려해볼만한 다른 방법이 있는지, 또 실무에서는 어떠한 흐름을 통해 이벤트를 핸들링하는지 알고 싶습니다.


---

## ⚠️ 특이사항 / 참고 사항
- 현재 #58 완료 이전상태입니다.