### PR TITLE
Feat: 백업 스케줄러 구현 [#69]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/config/BackupScheduler.java
+++ b/src/main/java/com/hrbank3/hrbank3/config/BackupScheduler.java
@@ -18,6 +18,8 @@ public class BackupScheduler {
     log.info("[BackupScheduler] 배치 작업 시작");
     try {
       backupHistoryService.backup("system");
+    } catch (IllegalStateException e) {
+      log.warn("[BackupScheduler] 이미 진행 중인 백업이 있습니다: {}", e.getMessage());
     } catch (Exception e) {
       log.error("[BackupScheduler] 배치 작업 중 예외 발생: ", e);
     }

--- a/src/main/java/com/hrbank3/hrbank3/config/BackupScheduler.java
+++ b/src/main/java/com/hrbank3/hrbank3/config/BackupScheduler.java
@@ -1,0 +1,26 @@
+package com.hrbank3.hrbank3.config;
+
+import com.hrbank3.hrbank3.service.BackupHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BackupScheduler {
+
+  private final BackupHistoryService backupHistoryService;
+
+  @Scheduled(cron = "${backup.schedule.cron}")
+  public void runBackup() {
+    log.info("[BackupScheduler] 배치 작업 시작");
+    try {
+      backupHistoryService.backup("system");
+    } catch (Exception e) {
+      log.error("[BackupScheduler] 배치 작업 중 예외 발생: ", e);
+    }
+  }
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/config/SchedulerConfig.java
+++ b/src/main/java/com/hrbank3/hrbank3/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.hrbank3.hrbank3.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryTransaction.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryTransaction.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -24,7 +25,7 @@ public class BackupHistoryTransaction {
     private final FileMetadataRepository fileMetadataRepository;
 
   // 백업 필요 여부 반한 후 IN_PROGRESS 또는 SKIPPED 이력 저장 메서드
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public BackupHistory initiate(String worker) {
     // IN_PROGRESS 중복 체크
     boolean isInProgress = backupHistoryRepository.existsByStatus(BackupStatus.IN_PROGRESS);
@@ -60,20 +61,20 @@ public class BackupHistoryTransaction {
     return employeeRepository.existsByUpdatedAtAfter(lastBackupTime);
   }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void complete(BackupHistory history, FileMetadata file) {
       history.updateComplete(file);
       backupHistoryRepository.save(history);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void fail(BackupHistory history, FileMetadata logFile) {
       history.updateFail(logFile);
       backupHistoryRepository.save(history);
     }
 
   // Path를 받아 FileMetadata 엔티티 생성 후 db 저장
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public FileMetadata saveFileMetadata(Path filePath, String contentType) throws IOException {
     String originalName = filePath.getFileName().toString();
     String storedName = UUID.randomUUID().toString();

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -18,3 +18,7 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
         show_sql: true
+
+backup:
+  schedule:
+    cron: "0 * * * * *" # 매 분마다 하도록 세팅

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -23,3 +23,7 @@ spring:
       file:
         upload:
           path: ./uploads/
+
+backup:
+  schedule:
+    cron: "-" # 로컬에선 스케줄러 주기 비활성화

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,5 @@ file:
 backup:
   dir: ${BACKUP_DIR:./backups/}
   chunk-size: 500
+  schedule:
+    cron: "0 0 * * * *" # 매 시 정각에 하도록 세팅


### PR DESCRIPTION
## 관련 이슈
- closes #69 

## 변경사항
- `@Scheduled`로 worker = `system`으로 주기마다 백업 배치 작업하게 설정
- 메인 클래스에 `@EnableScheduling`에 쓰는 게 아닌 별도 `SchedulerConfig` 클래스로 분리
- application.yml에는 기본 값(매 시 정각), dev환경에선 매 분마다, local 환경에서는 스케줄러 주기를 비활성화해두는 설정 추가. 
- 이번 프로젝트에선 Scheduler를 사용하는 것이 백업말곤 없어서 `BackupScheduler` 클래스를 별도 패키지에 두는 것이 아닌 config 패키지에 같이 넣어두었음.
- `BackupHistoryTransaction`의 트랜잭션 어노테이션이 붙어있는 메서드들에 propagation = Propagation.REQUIRES_NEW 전파 옵션 추가
    - 기존 트랜잭션과 완전히 독립된 새 트랜잭션을 만들어 즉시 커밋하는 옵션
    - 기본 값은 REQUIRED인데, 현재는 `BackupHistoryService`에 @Transactional 어노테이션이 없어서 괜찮지만, 실수로 추가하게 되면 부모 트랜잭션에 자식 트랜잭션이 합류하게 되어 부모 트랜잭션이 커밋될 때 한번에 커밋되게 됨. REQUIRES_NEW 옵션을 추가함으로써 그런 실수가 일어나더라도 부모 트랜잭션을 일시 중단하고 새 트랜잭션 시작 후 부모 트랜잭션을 재개하므로 이력 등록 후 csv 생성 중에 외부 조회시에 이미 커밋되어 문제가 되지 않음. 


## 테스트
- [x] 로컬 테스트 완료

## 스크린샷 (선택)
<img width="1107" height="454" alt="스크린샷 2026-04-20 오후 4 39 43" src="https://github.com/user-attachments/assets/c030b74b-42cd-46e4-bcb9-a5ed546abd0e" />
