### PR TITLE
Feat: 부서 단건 조회/등록/수정 employeeCount 연동 [#75]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import com.hrbank3.hrbank3.entity.Department;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long>,
     EmployeeRepositoryCustom {
@@ -42,7 +43,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
   @Query("SELECT e FROM Employee e LEFT JOIN FETCH e.profileImage")
   Slice<Employee> findAllWithProfileImage(Pageable pageable);
 
-  boolean existsByDepartmentId(Long departmentId);
+  boolean existsByDepartment(Department department);
 
   long countByStatus(EmployeeStatus status);
 

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeRepository.java
@@ -48,4 +48,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
 
   long countByHireDateBetweenAndStatus(LocalDate from, LocalDate to, EmployeeStatus status);
 
+  long countByDepartmentIdAndStatusNot(Long departmentId, EmployeeStatus status);
+
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -5,11 +5,12 @@ import com.hrbank3.hrbank3.dto.department.DepartmentDto;
 import com.hrbank3.hrbank3.dto.department.DepartmentCreateRequest;
 import com.hrbank3.hrbank3.dto.department.DepartmentUpdateRequest;
 import com.hrbank3.hrbank3.entity.Department;
+import com.hrbank3.hrbank3.entity.enums.EmployeeStatus;
 import com.hrbank3.hrbank3.repository.DepartmentRepository;
+import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.hrbank3.hrbank3.repository.EmployeeRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -21,17 +22,14 @@ public class DepartmentService {
 
     // 부서 등록
     public DepartmentDto create(DepartmentCreateRequest request) {
-        // 이름 중복 체크
         if (departmentRepository.existsByName(request.name())) {
             throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
         }
-
         Department department = new Department(
                 request.name(),
                 request.description(),
                 request.establishedDate()
         );
-
         Department saved = departmentRepository.save(department);
         return toDto(saved);
     }
@@ -41,13 +39,10 @@ public class DepartmentService {
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
 
-        // 자기 자신 제외하고 이름 중복 체크
         if (departmentRepository.existsByNameAndIdNot(request.name(), id)) {
             throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
         }
-
         department.update(request.name(), request.description(), request.establishedDate());
-
         return toDto(department);
     }
 
@@ -56,12 +51,10 @@ public class DepartmentService {
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
 
-        // 소속 직원 유무 체크 추가
         boolean hasEmployees = employeeRepository.existsByDepartmentId(id);
         if (hasEmployees) {
             throw new IllegalStateException("소속 직원이 있는 부서는 삭제할 수 없습니다.");
         }
-
         departmentRepository.delete(department);
     }
 
@@ -69,13 +62,14 @@ public class DepartmentService {
     @Transactional(readOnly = true)
     public CursorPageResponseDto<DepartmentDto> findAll(
             String nameOrDescription,
-            String sortBy,
+            String sortField,
             String sortDirection,
-            Long lastId,
+            Long idAfter,
             int size) {
         return departmentRepository.findAllWithCursor(
-                nameOrDescription, sortBy, sortDirection, lastId, size);
+                nameOrDescription, sortField, sortDirection, idAfter, size);
     }
+
     // 부서 단건 조회
     @Transactional(readOnly = true)
     public DepartmentDto findById(Long id) {
@@ -84,8 +78,10 @@ public class DepartmentService {
         return toDto(department);
     }
 
-    // Entity -> DTO 변환
+    // Entity -> DTO 변환 (실제 직원 수 조회)
     private DepartmentDto toDto(Department department) {
+        long count = employeeRepository.countByDepartmentIdAndStatusNot(
+                department.getId(), EmployeeStatus.RESIGNED);
         return new DepartmentDto(
                 department.getId(),
                 department.getName(),
@@ -93,7 +89,7 @@ public class DepartmentService {
                 department.getEstablishedDate(),
                 department.getCreatedAt(),
                 department.getUpdatedAt(),
-                0L  // 직원 연동 전까지 임시로 0
+                count
         );
     }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -51,7 +51,9 @@ public class DepartmentService {
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
 
-        boolean hasEmployees = employeeRepository.existsByDepartmentId(id);
+        // 변경 전: employeeRepository.existsByDepartmentId(id)
+        // 변경 후: department 객체 직접 전달
+        boolean hasEmployees = employeeRepository.existsByDepartment(department);
         if (hasEmployees) {
             throw new IllegalStateException("소속 직원이 있는 부서는 삭제할 수 없습니다.");
         }


### PR DESCRIPTION
## 관련 이슈
- closes #75 

## 📋 PR 기본 정보
- **프로젝트**: 초급
- **주차**: 12주차
- **PR 요약**: 부서 단건 조회/등록/수정 시 employeeCount DB 조회로 연동

---

## 🛠 구현 내용
- DepartmentService의 toDto() 메서드에서 0L 하드코딩 제거
- EmployeeRepository에 countByDepartmentIdAndStatusNot 메서드 추가
- 부서 등록/수정/단건 조회 시 퇴사자 제외한 실제 직원 수 반환

---

## 🔍 코드리뷰 요청 사항

### 요청 1
- **파일/위치**: src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java- toDto()메서드
- **요청 내용**: 부서 등록/수정/단건 조회 시 매번 toDto()를 호출하면서 직원 수 쿼리가 추가 실행됩니다. 이런 방식이 적절한지, 아니면 더 효율적인 방법이 있는지 궁금합니다.
- **고민한 점**: 직원 수가 자주 변경되는 데이터라 캐싱도 어렵고, 그렇다고 매번 쿼리를 날리는 것도 비효율적인 것 같아서 고민했습니다.

### 요청 2
- **파일/위치**: src/main/java/com/hrbank3/hrbank3/dto/CursorPageResponseDto.java
- **요청 내용**: 현재 nextCursor(String)와 nextIdAfter(Long) 두 개의 필드를 같이 반환하고 있습니다. 두 필드가 사실상 같은 값인데 하나로 줄이는 게 나은지, 아니면 두 개를 유지하는 게 나은지 궁금합니다.
- **고민한 점**: 프론트엔드에서 어떤 필드를 사용하는지 확인했어야 했는데, 일단 둘 다 반환하는 방식으로 구현했습니다.

---

## ⚠️ 특이사항 / 참고 사항
- 부서 목록 조회(DepartmentRepositoryImpl)의 employeeCount 연동은 이전 PR(#71)에서 완료되었고, 이번 PR은 단건 조회/등록/수정에 동일하게 적용한 내용입니다.