### PR TITLE
Feat: 직원 수정 이력 목록 다건 조회 API 구현

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
@@ -1,7 +1,10 @@
 package com.hrbank3.hrbank3.controller;
 
 import com.hrbank3.hrbank3.common.exception.ErrorResponse;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
 import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDetailDto;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDto;
+import com.hrbank3.hrbank3.repository.condition.ChangeLogSearchCondition;
 import com.hrbank3.hrbank3.service.EmployeeAuditHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,8 +13,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +29,7 @@ public class EmployeeAuditHistoryController {
 
   private final EmployeeAuditHistoryService auditHistoryService;
 
-  @Operation(summary = "직원 정보 수정 이력 상세 조회", description = "특정 수정 이력의 상세 변경 내역을 조회합니다.")
+  @Operation(summary = "직원 정보 수정 이력 상세 조회", description = "직원 정보 수정 이력의 상세 정보를 조회합니다. 변경 상세 내용이 포함됩니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "조회 성공"),
       @ApiResponse(
@@ -40,7 +45,19 @@ public class EmployeeAuditHistoryController {
   })
   @GetMapping("/{id}")
   public ResponseEntity<ChangeLogDetailDto> getChangeLogDetail(@PathVariable("id") Long id) {
-    ChangeLogDetailDto detailDto = auditHistoryService.getAuditDetail(id);
+    ChangeLogDetailDto detailDto = auditHistoryService.find(id);
     return ResponseEntity.ok(detailDto);
+  }
+
+  @Operation(summary = "직원 정보 수정 이력 목록 조회", description = "직원 정보 수정 이력 목록을 조회합니다. 상세 변경 내용은 포함되지 않습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 지원하지 않는 정렬 필드"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @GetMapping
+  public ResponseEntity<CursorPageResponseDto<ChangeLogDto>> findAll(
+      @ParameterObject @ModelAttribute ChangeLogSearchCondition condition) {
+    return ResponseEntity.ok(auditHistoryService.findAll(condition));
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/dto/audit_history/ChangeLogDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/audit_history/ChangeLogDto.java
@@ -1,0 +1,15 @@
+package com.hrbank3.hrbank3.dto.audit_history;
+
+import com.hrbank3.hrbank3.entity.enums.AuditType;
+import java.time.Instant;
+
+public record ChangeLogDto(
+    Long id,
+    AuditType type,
+    String employeeNumber,
+    String memo,
+    String ipAddress,
+    Instant at
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepositoryImpl.java
@@ -1,0 +1,177 @@
+package com.hrbank3.hrbank3.repository;
+
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDto;
+import com.hrbank3.hrbank3.entity.QEmployeeAuditHistory;
+import com.hrbank3.hrbank3.entity.enums.AuditType;
+import com.hrbank3.hrbank3.repository.condition.ChangeLogSearchCondition;
+import com.hrbank3.hrbank3.repository.custom.EmployeeAuditHistoryRepositoryCustom;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class EmployeeAuditHistoryRepositoryImpl implements EmployeeAuditHistoryRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+  private final QEmployeeAuditHistory history = QEmployeeAuditHistory.employeeAuditHistory;
+
+  @Override
+  public CursorPageResponseDto<ChangeLogDto> findAllWithCursor(ChangeLogSearchCondition condition) {
+    BooleanBuilder builder = new BooleanBuilder();
+
+    // 필터링 조건 추가
+    builder.and(employeeNumberContains(condition.getEmployeeNumber()))
+        .and(typeEq(condition.getType()))
+        .and(memoContains(condition.getMemo()))
+        .and(ipAddressContains(condition.getIpAddress()))
+        .and(createdAtBetween(condition.getAtFrom(), condition.getAtTo()));
+
+    // 전체 데이터 개수 조회
+    long totalElements = Optional.ofNullable(
+        queryFactory.select(history.count()).from(history).where(builder).fetchOne()
+    ).orElse(0L);
+
+    // 커서 페이징 조건 추가
+    builder.and(
+        cursorCondition(condition.getCursor(), condition.getIdAfter(), condition.getSortField(),
+            condition.getSortDirection()));
+
+    // 데이터 조회
+    List<ChangeLogDto> results = queryFactory
+        .select(Projections.constructor(ChangeLogDto.class,
+            history.id,
+            history.auditType,
+            history.targetEmployeeNo,
+            history.memo,
+            history.ipAddress,
+            history.createdAt
+        ))
+        .from(history)
+        .where(builder)
+        .orderBy(resolveOrderSpecifiers(condition.getSortField(), condition.getSortDirection()))
+        .limit(condition.getSize() + 1) // 다음 페이지가 있는지 확인하기 위해 1개 더 조회
+        .fetch();
+
+    // 다음 페이지 존재 여부 확인
+    boolean hasNext = results.size() > condition.getSize();
+    if (hasNext) {
+      results = results.subList(0, condition.getSize());
+    }
+
+    // 다음 페이지를 위한 커서 값 생성
+    String nextCursor = null;
+    Long nextIdAfter = null;
+    if (hasNext) {
+      ChangeLogDto lastItem = results.get(results.size() - 1);
+      nextIdAfter = lastItem.id();
+      // 시간/IP주소 정렬 기준에 따라 다음 커서값 세팅
+      nextCursor = "ipAddress".equals(condition.getSortField())
+          ? lastItem.ipAddress()
+          : lastItem.at().toString();
+    }
+
+    return new CursorPageResponseDto<>(results, nextCursor, nextIdAfter, results.size(),
+        totalElements, hasNext);
+  }
+
+  /*필터링 조건 메서드*/
+
+  private BooleanExpression employeeNumberContains(String employeeNumber) {
+    return StringUtils.hasText(employeeNumber) ? history.targetEmployeeNo.contains(employeeNumber)
+        : null;
+  }
+
+  private BooleanExpression typeEq(AuditType type) {
+    return type != null ? history.auditType.eq(type) : null;
+  }
+
+  private BooleanExpression memoContains(String memo) {
+    return StringUtils.hasText(memo) ? history.memo.contains(memo) : null;
+  }
+
+  private BooleanExpression ipAddressContains(String ipAddress) {
+    return StringUtils.hasText(ipAddress) ? history.ipAddress.contains(ipAddress) : null;
+  }
+
+  private BooleanExpression createdAtBetween(java.time.ZonedDateTime from,
+      java.time.ZonedDateTime to) {
+    if (from == null && to == null) {
+      return null;
+    }
+    Instant fromInstant = from != null ? from.toInstant() : null;
+    Instant toInstant = to != null ? to.toInstant() : null;
+
+    if (fromInstant == null) {
+      return history.createdAt.loe(toInstant);
+    }
+    if (toInstant == null) {
+      return history.createdAt.goe(fromInstant);
+    }
+    return history.createdAt.between(fromInstant, toInstant);
+  }
+
+  /*커서 및 정렬 로직*/
+
+  // 동적 커서 비교 로직
+  private BooleanExpression cursorCondition(String cursor, Long lastId, String sortField,
+      String sortDirection) {
+    if ((StringUtils.hasText(cursor) && lastId == null) ||
+        (!StringUtils.hasText(cursor) && lastId != null)) {
+      throw new IllegalArgumentException("cursor와 idAfter는 반드시 함께 사용되어야 합니다.");
+    }
+
+    if (!StringUtils.hasText(cursor) || lastId == null) {
+      return null;
+    }
+
+    boolean isAsc = "asc".equalsIgnoreCase(sortDirection);
+
+    if ("ipAddress".equals(sortField)) {
+      // IP 정렬일 때 커서 처리
+      if (isAsc) {
+        return history.ipAddress.gt(cursor)
+            .or(history.ipAddress.eq(cursor).and(history.id.gt(lastId)));
+      } else {
+        return history.ipAddress.lt(cursor)
+            .or(history.ipAddress.eq(cursor).and(history.id.lt(lastId)));
+      }
+    } else {
+      // at 정렬일 때 커서 처리
+      Instant cursorInstant = Instant.parse(cursor);
+      if (isAsc) {
+        return history.createdAt.gt(cursorInstant)
+            .or(history.createdAt.eq(cursorInstant).and(history.id.gt(lastId)));
+      } else {
+        return history.createdAt.lt(cursorInstant)
+            .or(history.createdAt.eq(cursorInstant).and(history.id.lt(lastId)));
+      }
+    }
+  }
+
+  // 동적 정렬 로직
+  private OrderSpecifier<?>[] resolveOrderSpecifiers(String sortField, String sortDirection) {
+    boolean isAsc = "asc".equalsIgnoreCase(sortDirection);
+
+    if ("ipAddress".equals(sortField)) {
+      return new OrderSpecifier[]{
+          isAsc ? history.ipAddress.asc() : history.ipAddress.desc(),
+          isAsc ? history.id.asc() : history.id.desc()
+      };
+    } else {
+      return new OrderSpecifier[]{
+          isAsc ? history.createdAt.asc() : history.createdAt.desc(),
+          isAsc ? history.id.asc() : history.id.desc()
+      };
+    }
+  }
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepositoryImpl.java
@@ -125,10 +125,6 @@ public class EmployeeAuditHistoryRepositoryImpl implements EmployeeAuditHistoryR
   // 동적 커서 비교 로직
   private BooleanExpression cursorCondition(String cursor, Long lastId, String sortField,
       String sortDirection) {
-    if ((StringUtils.hasText(cursor) && lastId == null) ||
-        (!StringUtils.hasText(cursor) && lastId != null)) {
-      throw new IllegalArgumentException("cursor와 idAfter는 반드시 함께 사용되어야 합니다.");
-    }
 
     if (!StringUtils.hasText(cursor) || lastId == null) {
       return null;

--- a/src/main/java/com/hrbank3/hrbank3/repository/condition/ChangeLogSearchCondition.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/condition/ChangeLogSearchCondition.java
@@ -1,0 +1,50 @@
+package com.hrbank3.hrbank3.repository.condition;
+
+import com.hrbank3.hrbank3.entity.enums.AuditType;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.time.ZonedDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangeLogSearchCondition {
+
+  // 검색 필터
+  @Parameter(description = "대상 직원 사번")
+  private String employeeNumber;
+
+  @Parameter(description = "이력 유형 (CREATED, UPDATED, DELETED)")
+  private AuditType type;
+
+  @Parameter(description = "내용")
+  private String memo;
+
+  @Parameter(description = "IP 주소")
+  private String ipAddress;
+
+  @Parameter(description = "수정 일시(부터)")
+  private ZonedDateTime atFrom;
+
+  @Parameter(description = "수정 일시(까지)")
+  private ZonedDateTime atTo;
+
+
+  // 페이징 및 정렬
+  @Parameter(description = "이전 페이지 마지막 요소 ID")
+  private Long idAfter;
+
+  @Parameter(description = "커서 (이전 페이지의 마지막 ID)")
+  private String cursor;
+
+  @Parameter(description = "페이지 크기")
+  private int size = 10;
+
+  @Parameter(description = "정렬 필드 (ipAddress, at")
+  private String sortField = "at";
+
+  @Parameter(description = "정렬 방향 (asc, desc)")
+  private String sortDirection = "desc";
+}

--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/EmployeeAuditHistoryRepositoryCustom.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/EmployeeAuditHistoryRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.hrbank3.hrbank3.repository.custom;
+
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDto;
+import com.hrbank3.hrbank3.repository.condition.ChangeLogSearchCondition;
+
+public interface EmployeeAuditHistoryRepositoryCustom {
+
+  // 다건 목록 조회 (커서 페이징 + 동적 필터링)
+  CursorPageResponseDto<ChangeLogDto> findAllWithCursor(ChangeLogSearchCondition condition);
+}

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -1,13 +1,17 @@
 package com.hrbank3.hrbank3.service;
 
 import com.hrbank3.hrbank3.common.util.IpExtractUtil;
+import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
 import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDetailDto;
+import com.hrbank3.hrbank3.dto.audit_history.ChangeLogDto;
 import com.hrbank3.hrbank3.dto.audit_history.DiffDto;
 import com.hrbank3.hrbank3.entity.EmployeeAuditHistory;
 import com.hrbank3.hrbank3.entity.enums.AuditType;
 import com.hrbank3.hrbank3.event.EmployeeAuditEvent;
 import com.hrbank3.hrbank3.repository.EmployeeAuditHistoryRepository;
 import com.hrbank3.hrbank3.repository.EmployeeRepository;
+import com.hrbank3.hrbank3.repository.condition.ChangeLogSearchCondition;
+import com.hrbank3.hrbank3.repository.custom.EmployeeAuditHistoryRepositoryCustom;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -24,10 +28,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmployeeAuditHistoryService {
 
   private final EmployeeAuditHistoryRepository auditRepository;
+  private final EmployeeAuditHistoryRepositoryCustom customAuditRepository;
   private final EmployeeRepository employeeRepository;
 
-
   // 직원 정보 수정 시 발생하는 핸들링
+
   @Transactional
   @EventListener
   public void recordAuditHistory(EmployeeAuditEvent event) {
@@ -72,15 +77,21 @@ public class EmployeeAuditHistoryService {
     return diffMap;
   }
 
+  @Transactional(readOnly = true)
+  public CursorPageResponseDto<ChangeLogDto> findAll(ChangeLogSearchCondition condition) {
+    return customAuditRepository.findAllWithCursor(condition);
+  }
+
   // 상세 데이터 읽기
   @Transactional(readOnly = true)
-  public ChangeLogDetailDto getAuditDetail(Long id) {
+  public ChangeLogDetailDto find(Long id) {
     EmployeeAuditHistory audit = auditRepository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
 
     List<DiffDto> diffs = audit.getChangedContent().entrySet().stream()
         .map(entry -> {
           if (!(entry.getValue() instanceof Map<?, ?> values)) {
+            // 만약 Map 형태가 아니라면 안전하게 기본값("-") 반환
             return new DiffDto(entry.getKey(), "-", "-");
           }
 
@@ -107,7 +118,7 @@ public class EmployeeAuditHistoryService {
     );
   }
 
-  // 사원 이름 및
+  // 사원 이름 및 프로필 이미지 추출
   private EmployeeInfo resolveEmployeeInfo(EmployeeAuditHistory audit, List<DiffDto> diffs) {
     return employeeRepository.findByEmployeeNumber(audit.getTargetEmployeeNo())
         .map(e -> new EmployeeInfo(

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +33,6 @@ public class EmployeeAuditHistoryService {
   private final EmployeeRepository employeeRepository;
 
   // 직원 정보 수정 시 발생하는 핸들링
-
   @Transactional
   @EventListener
   public void recordAuditHistory(EmployeeAuditEvent event) {
@@ -79,6 +79,8 @@ public class EmployeeAuditHistoryService {
 
   @Transactional(readOnly = true)
   public CursorPageResponseDto<ChangeLogDto> findAll(ChangeLogSearchCondition condition) {
+    validatePaginationParams(condition.getCursor(), condition.getIdAfter());
+
     return customAuditRepository.findAllWithCursor(condition);
   }
 
@@ -148,6 +150,13 @@ public class EmployeeAuditHistoryService {
               .orElse(null);
           return new EmployeeInfo(deletedName, deletedProfileId);
         });
+  }
+
+  private void validatePaginationParams(String cursor, Long idAfter) {
+    if ((StringUtils.hasText(cursor) && idAfter == null) ||
+        (!StringUtils.hasText(cursor) && idAfter != null)) {
+      throw new IllegalArgumentException("cursor와 idAfter는 반드시 함께 사용되어야 합니다.");
+    }
   }
 
   // 데이터 전달용 임시 레코드


### PR DESCRIPTION
## 관련 이슈
- closes #57 

## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 12주차
- **PR 요약**: 직원 정보 수정 이력 다건 조회 API 구현

---

## 🛠️ 구현 내용
직원 정보 수정 이력의 목록을 다건으로 조회하는 API와, 대용량 데이터 환경에서도 성능 저하 없이 조회가 가능한 커서 기반 페이지네이션 및 QueryDSL을 바탕으로 최적화를 구현했습니다.

- [x] 이력 목록 조회 및 프론트엔드 연동 규격에 맞춘 응답 객체 `ChangeLogDto` 추가
- [x] `EmployeeAuditHistoryController`에 `GET /api/change-logs `목록 조회 엔드포인트 구현
- [x] 대량의 데이터 조회 성능을 보장하기 위해 Offset 방식 대신 `cursor` 및 `idAfter`를 활용한 커서 기반 페이지네이션 로직 구현
- [x] QueryDSL을 적용하여 DB 엔티티 전체가 아닌 필요 필드만 선별적으로 조회하는 최적화 수행
- [x] 생성 일시(`createdAt`)와 IP 주소(`ipAddress`)에 대한 동적 정렬 및 사번, 유형, 기간별 복합 필터링 기능 추가
- [x] Swagger(OpenAPI) 명세에 `ParameterObject`를 적용하여 쿼리 파라미터 가독성 및 테스트 편의성 향상

---

## 🔍 코드리뷰 요청 사항
### 요청 1: 커서 페이징 커서 조건 및 문자열 IP 정렬 처리
- **파일/위치**: `src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepositoryImpl.java` 의 `cursorCondition() `및 `resolveOrderSpecifiers()` 메서드
- **요청 내용**: 요구사항에 따라 생성 일시(`createdAt`)와 IP 주소(`ipAddress`) 두 가지 정렬을 지원하도록 구현했습니다. 이 로직이 실무 쿼리 성능 관점에서 충분히 효율적인지 조언을 구하고 싶습니다.
- **고민한 점**: IP 주소가 DB에 `String`로 저장되어 있어, `10.0.x.x`가 `192.168.x.x`보다 뒤에 정렬되는 문제가 생기는 점을 인지했습니다. 이번 PR에서는 그대로 구현했으나, IP 정렬을 정확히 수행하려면 `Long` 타입으로 변경하는 식으로 변경해야 하는 지 궁금합니다.

### 요청 2: 정렬 필드(sortField)의 Enum 도입
- **파일/위치**: `src/main/java/com/hrbank3/hrbank3/repository/condition/ChangeLogSearchCondition.java`
- **요청 내용**: 현재 정렬 기준(`sortField`)을 문자열(`String`)로 받아서 처리하고 있습니다. 이를 `SortField Enum`으로 리팩토링하여 안정성을 높이는 것이 좋은 지 고민입니다.
- **고민한 점**: 만약 `Enum`으로 변경할 경우, 클라이언트가 잘못된 값을 보냈을 때 스프링 기본 예외(`TypeMismatchException`)가 발생할 것으로 예상됩니다. 실무에서는 보통 이런 바인딩 예외를 `@ExceptionHandler`로 잡아 커스텀 에러로 내려주는 편인지, 아니면 현재 제 코드처럼 String으로 받고 내부에서 분기 처리 및 예외를 던지는 방식을 유지하는 편인지 실무에선 어떠한 방식을 사용하는 지 알고 싶습니다!

---

## ⚠️ 특이사항 / 참고 사항
- 페이징을 위한 cursor 값은 프론트엔드 명세에 맞추어 순수 문자열 데이터 그대로 응답 및 요청받도록 처리했습니다.
- #73  '수정 이력 상세 단건 조회 API' 내용이 포함되어 있습니다.