### PR TITLE
Feat: Department 엔티티 DepartmentMail 필드 추가 [#78]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
@@ -1,16 +1,23 @@
 package com.hrbank3.hrbank3.dto.department;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record DepartmentCreateRequest(
 
-        @NotBlank(message = "부서 이름은 필수입니다")
-        String name,
+    @NotBlank(message = "부서 이름은 필수입니다")
+    String name,
 
-        String description,
+    String description,
 
-        @NotNull(message = "설립일은 필수입니다")
-        LocalDate establishedDate
-) {}
+    @NotNull(message = "설립일은 필수입니다")
+    LocalDate establishedDate,
+
+    @NotBlank(message = "부서 메일은 필수입니다")
+    @Email(message = "이메일 형식이 올바르지 않습니다")
+    String departmentEmail
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentDto.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentDto.java
@@ -4,11 +4,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DepartmentDto(
-        Long id,
-        String name,
-        String description,
-        LocalDate establishedDate,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        long employeeCount  // 부서 소속 직원 수
-) {}
+    Long id,
+    String name,
+    String description,
+    LocalDate establishedDate,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    long employeeCount,// 부서 소속 직원 수
+    String departmentEmail
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
@@ -1,16 +1,23 @@
 package com.hrbank3.hrbank3.dto.department;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record DepartmentUpdateRequest(
 
-        @NotBlank(message = "부서 이름은 필수입니다")
-        String name,
+    @NotBlank(message = "부서 이름은 필수입니다")
+    String name,
 
-        String description,
+    String description,
 
-        @NotNull(message = "설립일은 필수입니다")
-        LocalDate establishedDate
-) {}
+    @NotNull(message = "설립일은 필수입니다")
+    LocalDate establishedDate,
+
+    @NotBlank(message = "부서 메일은 필수입니다")
+    @Email(message = "이메일 형식이 올바르지 않습니다")
+    String departmentEmail
+) {
+
+}

--- a/src/main/java/com/hrbank3/hrbank3/entity/Department.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/Department.java
@@ -17,38 +17,45 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class Department {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
-    private String name;
+  @Column(nullable = false, unique = true, length = 100)
+  private String name;
 
-    @Column(length = 255)
-    private String description;
+  @Column(length = 255)
+  private String description;
 
-    @Column(nullable = false)
-    private LocalDate establishedDate;
+  @Column(nullable = false)
+  private LocalDate establishedDate;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  @Column(nullable = false, length = 255)
+  private String departmentEmail;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
 
-    // 생성 전용 생성자
-    public Department(String name, String description, LocalDate establishedDate) {
-        this.name = name;
-        this.description = description;
-        this.establishedDate = establishedDate;
-    }
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
 
-    // 수정 전용 메서드
-    public void update(String name, String description, LocalDate establishedDate) {
-        this.name = name;
-        this.description = description;
-        this.establishedDate = establishedDate;
-    }
+  // 생성 전용 생성자
+  public Department(String name, String description, LocalDate establishedDate,
+      String departmentEmail) {
+    this.name = name;
+    this.description = description;
+    this.establishedDate = establishedDate;
+    this.departmentEmail = departmentEmail;
+  }
+
+  // 수정 전용 메서드
+  public void update(String name, String description, LocalDate establishedDate,
+      String departmentEmail) {
+    this.name = name;
+    this.description = description;
+    this.establishedDate = establishedDate;
+    this.departmentEmail = departmentEmail;
+  }
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -18,90 +18,91 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+  private final JPAQueryFactory queryFactory;
 
-    @Override
-    public CursorPageResponseDto<DepartmentDto> findAllWithCursor(
-            String nameOrDescription,
-            String sortField,       // sortBy → sortField
-            String sortDirection,
-            Long idAfter,           // lastId → idAfter
-            int size) {
+  @Override
+  public CursorPageResponseDto<DepartmentDto> findAllWithCursor(
+      String nameOrDescription,
+      String sortField,       // sortBy → sortField
+      String sortDirection,
+      Long idAfter,           // lastId → idAfter
+      int size) {
 
-        QDepartment department = QDepartment.department;
-        QEmployee employee = QEmployee.employee;
-        BooleanBuilder builder = new BooleanBuilder();
+    QDepartment department = QDepartment.department;
+    QEmployee employee = QEmployee.employee;
+    BooleanBuilder builder = new BooleanBuilder();
 
-        // 키워드 필터링
-        if (nameOrDescription != null && !nameOrDescription.isBlank()) {
-            builder.and(
-                    department.name.containsIgnoreCase(nameOrDescription)
-                            .or(department.description.containsIgnoreCase(nameOrDescription))
-            );
-        }
-
-        // 전체 개수 조회
-        long totalElements = queryFactory
-                .selectFrom(department)
-                .where(builder)
-                .fetchCount();
-
-        // 커서 조건 추가
-        if (idAfter != null) {
-            builder.and(department.id.gt(idAfter));
-        }
-
-        // 정렬 및 조회
-        List<Department> results = queryFactory
-                .selectFrom(department)
-                .where(builder)
-                .orderBy("desc".equals(sortDirection)
-                        ? ("establishedDate".equals(sortField)
-                        ? department.establishedDate.desc()
-                        : department.name.desc())
-                        : ("establishedDate".equals(sortField)
-                        ? department.establishedDate.asc()
-                        : department.name.asc()))
-                .limit(size + 1)
-                .fetch();
-
-        // 다음 페이지 여부 확인
-        boolean hasNext = results.size() > size;
-        if (hasNext) {
-            results = results.subList(0, size);
-        }
-
-        // employeeCount 실제 조회
-        List<DepartmentDto> content = results.stream()
-                .map(d -> {
-                    Long count = queryFactory
-                            .select(employee.count())
-                            .from(employee)
-                            .where(employee.department.eq(d),
-                                    employee.status.ne(EmployeeStatus.RESIGNED))
-                            .fetchOne();
-                    return new DepartmentDto(
-                            d.getId(),
-                            d.getName(),
-                            d.getDescription(),
-                            d.getEstablishedDate(),
-                            d.getCreatedAt(),
-                            d.getUpdatedAt(),
-                            count != null ? count : 0L
-                    );
-                })
-                .collect(Collectors.toList());
-
-        String nextCursor = hasNext ? String.valueOf(results.get(results.size() - 1).getId()) : null;
-        Long nextIdAfter = hasNext ? results.get(results.size() - 1).getId() : null;
-
-        return new CursorPageResponseDto<>(
-                content,
-                nextCursor,
-                nextIdAfter,
-                content.size(),
-                totalElements,
-                hasNext
-        );
+    // 키워드 필터링
+    if (nameOrDescription != null && !nameOrDescription.isBlank()) {
+      builder.and(
+          department.name.containsIgnoreCase(nameOrDescription)
+              .or(department.description.containsIgnoreCase(nameOrDescription))
+      );
     }
+
+    // 전체 개수 조회
+    long totalElements = queryFactory
+        .selectFrom(department)
+        .where(builder)
+        .fetchCount();
+
+    // 커서 조건 추가
+    if (idAfter != null) {
+      builder.and(department.id.gt(idAfter));
+    }
+
+    // 정렬 및 조회
+    List<Department> results = queryFactory
+        .selectFrom(department)
+        .where(builder)
+        .orderBy("desc".equals(sortDirection)
+            ? ("establishedDate".equals(sortField)
+               ? department.establishedDate.desc()
+            : department.name.desc())
+            : ("establishedDate".equals(sortField)
+               ? department.establishedDate.asc()
+                : department.name.asc()))
+        .limit(size + 1)
+        .fetch();
+
+    // 다음 페이지 여부 확인
+    boolean hasNext = results.size() > size;
+    if (hasNext) {
+      results = results.subList(0, size);
+    }
+
+    // employeeCount 실제 조회
+    List<DepartmentDto> content = results.stream()
+        .map(d -> {
+          Long count = queryFactory
+              .select(employee.count())
+              .from(employee)
+              .where(employee.department.eq(d),
+                  employee.status.ne(EmployeeStatus.RESIGNED))
+              .fetchOne();
+          return new DepartmentDto(
+              d.getId(),
+              d.getName(),
+              d.getDescription(),
+              d.getEstablishedDate(),
+              d.getCreatedAt(),
+              d.getUpdatedAt(),
+              count != null ? count : 0L,
+              d.getDepartmentEmail()
+          );
+        })
+        .collect(Collectors.toList());
+
+    String nextCursor = hasNext ? String.valueOf(results.get(results.size() - 1).getId()) : null;
+    Long nextIdAfter = hasNext ? results.get(results.size() - 1).getId() : null;
+
+    return new CursorPageResponseDto<>(
+        content,
+        nextCursor,
+        nextIdAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
+  }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -17,81 +17,84 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DepartmentService {
 
-    private final DepartmentRepository departmentRepository;
-    private final EmployeeRepository employeeRepository;
+  private final DepartmentRepository departmentRepository;
+  private final EmployeeRepository employeeRepository;
 
-    // 부서 등록
-    public DepartmentDto create(DepartmentCreateRequest request) {
-        if (departmentRepository.existsByName(request.name())) {
-            throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
-        }
-        Department department = new Department(
-                request.name(),
-                request.description(),
-                request.establishedDate()
-        );
-        Department saved = departmentRepository.save(department);
-        return toDto(saved);
+  // 부서 등록
+  public DepartmentDto create(DepartmentCreateRequest request) {
+    if (departmentRepository.existsByName(request.name())) {
+      throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
     }
+    Department department = new Department(
+        request.name(),
+        request.description(),
+        request.establishedDate(),
+        request.departmentEmail()
+    );
+    Department saved = departmentRepository.save(department);
+    return toDto(saved);
+  }
 
-    // 부서 수정
-    public DepartmentDto update(Long id, DepartmentUpdateRequest request) {
-        Department department = departmentRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
+  // 부서 수정
+  public DepartmentDto update(Long id, DepartmentUpdateRequest request) {
+    Department department = departmentRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
 
-        if (departmentRepository.existsByNameAndIdNot(request.name(), id)) {
-            throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
-        }
-        department.update(request.name(), request.description(), request.establishedDate());
-        return toDto(department);
+    if (departmentRepository.existsByNameAndIdNot(request.name(), id)) {
+      throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
     }
+    department.update(request.name(), request.description(), request.establishedDate(),
+        request.departmentEmail());
+    return toDto(department);
+  }
 
-    // 부서 삭제
-    public void delete(Long id) {
-        Department department = departmentRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
+  // 부서 삭제
+  public void delete(Long id) {
+    Department department = departmentRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
 
-        // 변경 전: employeeRepository.existsByDepartmentId(id)
-        // 변경 후: department 객체 직접 전달
-        boolean hasEmployees = employeeRepository.existsByDepartment(department);
-        if (hasEmployees) {
-            throw new IllegalStateException("소속 직원이 있는 부서는 삭제할 수 없습니다.");
-        }
-        departmentRepository.delete(department);
+    // 변경 전: employeeRepository.existsByDepartmentId(id)
+    // 변경 후: department 객체 직접 전달
+    boolean hasEmployees = employeeRepository.existsByDepartment(department);
+    if (hasEmployees) {
+      throw new IllegalStateException("소속 직원이 있는 부서는 삭제할 수 없습니다.");
     }
+    departmentRepository.delete(department);
+  }
 
-    // 부서 목록 조회 (커서 페이지네이션)
-    @Transactional(readOnly = true)
-    public CursorPageResponseDto<DepartmentDto> findAll(
-            String nameOrDescription,
-            String sortField,
-            String sortDirection,
-            Long idAfter,
-            int size) {
-        return departmentRepository.findAllWithCursor(
-                nameOrDescription, sortField, sortDirection, idAfter, size);
-    }
+  // 부서 목록 조회 (커서 페이지네이션)
+  @Transactional(readOnly = true)
+  public CursorPageResponseDto<DepartmentDto> findAll(
+      String nameOrDescription,
+      String sortField,
+      String sortDirection,
+      Long idAfter,
+      int size) {
+    return departmentRepository.findAllWithCursor(
+        nameOrDescription, sortField, sortDirection, idAfter, size);
+  }
 
-    // 부서 단건 조회
-    @Transactional(readOnly = true)
-    public DepartmentDto findById(Long id) {
-        Department department = departmentRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
-        return toDto(department);
-    }
+  // 부서 단건 조회
+  @Transactional(readOnly = true)
+  public DepartmentDto findById(Long id) {
+    Department department = departmentRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 부서입니다: " + id));
+    return toDto(department);
+  }
 
-    // Entity -> DTO 변환 (실제 직원 수 조회)
-    private DepartmentDto toDto(Department department) {
-        long count = employeeRepository.countByDepartmentIdAndStatusNot(
-                department.getId(), EmployeeStatus.RESIGNED);
-        return new DepartmentDto(
-                department.getId(),
-                department.getName(),
-                department.getDescription(),
-                department.getEstablishedDate(),
-                department.getCreatedAt(),
-                department.getUpdatedAt(),
-                count
-        );
-    }
+  // Entity -> DTO 변환 (실제 직원 수 조회)
+  private DepartmentDto toDto(Department department) {
+    long count = employeeRepository.countByDepartmentIdAndStatusNot(
+        department.getId(), EmployeeStatus.RESIGNED);
+    return new DepartmentDto(
+        department.getId(),
+        department.getName(),
+        department.getDescription(),
+        department.getEstablishedDate(),
+        department.getCreatedAt(),
+        department.getUpdatedAt(),
+        count,
+        department.getDepartmentEmail()
+    );
+  }
 }

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS departments (
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
     established_date DATE NOT NULL,
+    department_mail VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS departments (
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
     established_date DATE NOT NULL,
+    depratment_mail VARCHAR(255) NOT NULL,
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL
 );


### PR DESCRIPTION
## 관련 이슈
- closes #78

## 변경사항
- Department 엔티티에 departmentMail 필드 추가했습니다.
- DepartmentCreateRequest, DepartmentUpdateRequest DTO에 departmentMail 추가했습니다.
- DepartmentDto에 departmentMail 추가했습니다.
- DepartmentService create(), update(), toDto()에 departmentMail 연동했습니다.
- DepartmentRepositoryImpl에 DepartmentDto 생성 시 departmentMail 추가했습니다.
- schema-h2.sql, schema-postgres.sql departments 테이블에 department_mail 컬럼 추가했습니다.

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인

## 특이사항 / 참고 사항
- 부서 삭제 시 department_mail도 함께 삭제되지만, notifications 테이블의 department_id는 NULLABLE로 설계되어 알림 발송 이력은 부서 삭제 후에도 기록으로 남아있습니다.
- PostgreSQL 환경에서는 아래 쿼리 실행 부탁드립니다!
  ALTER TABLE departments ADD COLUMN department_mail VARCHAR(255);