### PR TITLE
Feat: 직원/백업 알림 이벤트 발행 연동 및 departmentMail nullable 처리 [#64]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
@@ -39,10 +39,10 @@ public class EmployeeController {
   @Operation(summary = "직원 등록")
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<EmployeeDto> create(
-          @RequestPart(value = "employee")
-          @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-          @Valid EmployeeCreateRequest request,
-          @RequestPart(value = "profile", required = false) MultipartFile profile
+      @RequestPart(value = "employee")
+      @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+      @Valid EmployeeCreateRequest request,
+      @RequestPart(value = "profile", required = false) MultipartFile profile
   ) {
     return ResponseEntity.status(HttpStatus.CREATED).body(employeeService.create(request, profile));
   }
@@ -50,23 +50,23 @@ public class EmployeeController {
   @Operation(summary = "직원 목록 조회")
   @GetMapping
   public ResponseEntity<CursorPageResponseDto<EmployeeDto>> findAll(
-          @RequestParam(required = false) String nameOrEmail,
-          @RequestParam(required = false) String employeeNumber,
-          @RequestParam(required = false) String departmentName,
-          @RequestParam(required = false) String position,
-          @RequestParam(required = false) LocalDate hireDateFrom,
-          @RequestParam(required = false) LocalDate hireDateTo,
-          @RequestParam(required = false) EmployeeStatus status,
-          @RequestParam(required = false) Long idAfter,
-          @RequestParam(required = false) String cursor,
-          @RequestParam(defaultValue = "10") int size,
-          @RequestParam(defaultValue = "name") String sortField,
-          @RequestParam(defaultValue = "asc") String sortDirection
+      @RequestParam(required = false) String nameOrEmail,
+      @RequestParam(required = false) String employeeNumber,
+      @RequestParam(required = false) String departmentName,
+      @RequestParam(required = false) String position,
+      @RequestParam(required = false) LocalDate hireDateFrom,
+      @RequestParam(required = false) LocalDate hireDateTo,
+      @RequestParam(required = false) EmployeeStatus status,
+      @RequestParam(required = false) Long idAfter,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "name") String sortField,
+      @RequestParam(defaultValue = "asc") String sortDirection
   ) {
     EmployeeSearchCondition condition = new EmployeeSearchCondition(
-            nameOrEmail, employeeNumber, departmentName, position,
-            hireDateFrom, hireDateTo, status, idAfter, cursor,
-            size, sortField, sortDirection
+        nameOrEmail, employeeNumber, departmentName, position,
+        hireDateFrom, hireDateTo, status, idAfter, cursor,
+        size, sortField, sortDirection
     );
     return ResponseEntity.ok(employeeService.findAll(condition));
   }
@@ -80,9 +80,9 @@ public class EmployeeController {
   @Operation(summary = "직원 수정")
   @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<EmployeeDto> update(
-          @PathVariable Long id,
-          @RequestPart("employee") @Valid EmployeeUpdateRequest request,
-          @RequestPart(value = "profile", required = false) MultipartFile profile
+      @PathVariable Long id,
+      @RequestPart("employee") @Valid EmployeeUpdateRequest request,
+      @RequestPart(value = "profile", required = false) MultipartFile profile
   ) {
     return ResponseEntity.ok(employeeService.update(id, request, profile));
   }
@@ -97,12 +97,12 @@ public class EmployeeController {
   @Operation(summary = "직원 수 추이 조회", description = "지정된 기간 및 시간 단위로 그룹화된 직원 수 추이를 조회합니다. 파라미터를 제공하지 않으면 최근 12개월 데이터를 월 단위로 반환합니다.")
   @GetMapping("/stats/trend")
   public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend(
-          @Parameter(description = "시작 일시 (기본값: 현재로부터 unit 기준 12개 이전)")
-          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-          @Parameter(description = "종료 일시 (기본값: 현재)")
-          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
-          @Parameter(description = "시간 단위 (day, week, month, quarter, year, 기본값: month)")
-          @RequestParam(required = false, defaultValue = "month") TrendUnit unit
+      @Parameter(description = "시작 일시 (기본값: 현재로부터 unit 기준 12개 이전)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @Parameter(description = "종료 일시 (기본값: 현재)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      @Parameter(description = "시간 단위 (day, week, month, quarter, year, 기본값: month)")
+      @RequestParam(required = false, defaultValue = "month") TrendUnit unit
   ) {
     return ResponseEntity.ok(dashboardService.getEmployeeTrend(from, to, unit));
   }
@@ -110,10 +110,11 @@ public class EmployeeController {
   @Operation(summary = "직원 분포 조회", description = "지정된 기준으로 그룹화된 직원 분포를 조회합니다.")
   @GetMapping("/stats/distribution")
   public ResponseEntity<List<EmployeeDistributionDto>> getDistribution(
-          @Parameter(description = "그룹화 기준 (department: 부서별, position: 직무별, 기본값: department)")
-          @RequestParam(defaultValue = "department") String groupBy,
-          @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사, 기본값: 재직중)", schema = @Schema(allowableValues = {"ACTIVE", "ON_LEAVE", "RESIGNED"}))
-          @RequestParam(required = false) EmployeeStatus status
+      @Parameter(description = "그룹화 기준 (department: 부서별, position: 직무별, 기본값: department)")
+      @RequestParam(defaultValue = "department") String groupBy,
+      @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사, 기본값: 재직중)", schema = @Schema(allowableValues = {
+          "ACTIVE", "ON_LEAVE", "RESIGNED"}))
+      @RequestParam(required = false) EmployeeStatus status
   ) {
     return ResponseEntity.ok(dashboardService.getDistribution(groupBy, status));
   }
@@ -121,12 +122,13 @@ public class EmployeeController {
   @Operation(summary = "직원 수 조회", description = "지정된 조건에 맞는 직원 수를 조회합니다. 상태 필터링 및 입사일 기간 필터링이 가능합니다.")
   @GetMapping("/count")
   public ResponseEntity<Long> getEmployeeCount(
-          @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사)", schema = @Schema(allowableValues = {"ACTIVE", "ON_LEAVE", "RESIGNED"}))
-          @RequestParam(required = false) EmployeeStatus status,
-          @Parameter(description = "입사일 시작 (지정 시 해당 기간 내 입사한 직원 수 조회, 미지정 시 전체 직원 수 조회)")
-          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
-          @Parameter(description = "입사일 종료 (fromDate와 함께 사용, 기본값: 현재 일시)")
-          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
+      @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사)", schema = @Schema(allowableValues = {"ACTIVE",
+          "ON_LEAVE", "RESIGNED"}))
+      @RequestParam(required = false) EmployeeStatus status,
+      @Parameter(description = "입사일 시작 (지정 시 해당 기간 내 입사한 직원 수 조회, 미지정 시 전체 직원 수 조회)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+      @Parameter(description = "입사일 종료 (fromDate와 함께 사용, 기본값: 현재 일시)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
   ) {
     return ResponseEntity.ok(dashboardService.getEmployeeCount(status, fromDate, toDate));
   }

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentCreateRequest.java
@@ -1,6 +1,5 @@
 package com.hrbank3.hrbank3.dto.department;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -15,9 +14,7 @@ public record DepartmentCreateRequest(
     @NotNull(message = "설립일은 필수입니다")
     LocalDate establishedDate,
 
-    @NotBlank(message = "부서 메일은 필수입니다")
-    @Email(message = "이메일 형식이 올바르지 않습니다")
-    String departmentEmail
+    String departmentMail
 ) {
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
@@ -17,7 +17,7 @@ public record DepartmentUpdateRequest(
 
     @NotBlank(message = "부서 메일은 필수입니다")
     @Email(message = "이메일 형식이 올바르지 않습니다")
-    String departmentEmail
+    String departmentMail
 ) {
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/entity/Department.java
+++ b/src/main/java/com/hrbank3/hrbank3/entity/Department.java
@@ -30,8 +30,8 @@ public class Department {
   @Column(nullable = false)
   private LocalDate establishedDate;
 
-  @Column(nullable = false, length = 255)
-  private String departmentEmail;
+  @Column(length = 255)
+  private String departmentMail;
 
   @CreatedDate
   @Column(nullable = false, updatable = false)
@@ -43,19 +43,19 @@ public class Department {
 
   // 생성 전용 생성자
   public Department(String name, String description, LocalDate establishedDate,
-      String departmentEmail) {
+      String departmentMail) {
     this.name = name;
     this.description = description;
     this.establishedDate = establishedDate;
-    this.departmentEmail = departmentEmail;
+    this.departmentMail = departmentMail;
   }
 
   // 수정 전용 메서드
   public void update(String name, String description, LocalDate establishedDate,
-      String departmentEmail) {
+      String departmentMail) {
     this.name = name;
     this.description = description;
     this.establishedDate = establishedDate;
-    this.departmentEmail = departmentEmail;
+    this.departmentMail = departmentMail;
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/event/BackupNotificationEvent.java
+++ b/src/main/java/com/hrbank3/hrbank3/event/BackupNotificationEvent.java
@@ -6,7 +6,7 @@ public record BackupNotificationEvent(
     String eventType, // BACKUP_SUCCESS, BACKUP_FAILED
     Instant startedAt,
     Instant endedAt,  // 완료(실패) 시각
-    String eroorMessage // 성공시 null
+    String errorMessage // 성공시 null
 ) {
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -88,7 +88,7 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
               d.getCreatedAt(),
               d.getUpdatedAt(),
               count != null ? count : 0L,
-              d.getDepartmentEmail()
+              d.getDepartmentMail()
           );
         })
         .collect(Collectors.toList());

--- a/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/BackupHistoryService.java
@@ -5,6 +5,7 @@ import com.hrbank3.hrbank3.dto.backupHistory.CursorPageResponseBackupDto;
 import com.hrbank3.hrbank3.entity.Department;
 import com.hrbank3.hrbank3.entity.Employee;
 import com.hrbank3.hrbank3.entity.FileMetadata;
+import com.hrbank3.hrbank3.event.BackupNotificationEvent;
 import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import com.hrbank3.hrbank3.entity.BackupHistory;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -45,6 +47,7 @@ public class BackupHistoryService {
   private final BackupHistoryMapper backupHistoryMapper;
   private final DepartmentRepository departmentRepository;
   private final BackupHistoryTransaction backupHistoryTransaction;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Value("${backup.dir}")
   private String backupDir;
@@ -106,6 +109,12 @@ public class BackupHistoryService {
       csvPath = writeCsv();
       FileMetadata file = backupHistoryTransaction.saveFileMetadata(csvPath, "text/csv");
       backupHistoryTransaction.complete(history, file);
+      eventPublisher.publishEvent(new BackupNotificationEvent(
+          "BACKUP_SUCCESS",
+          history.getStartedAt(),
+          history.getEndedAt(),
+          null
+      ));
     } catch (Exception e) {
       deleteSilently(csvPath);
       try {
@@ -115,6 +124,12 @@ public class BackupHistoryService {
       } catch (IOException logException) {
         // 로그 저장도 실패 시 파일 없이 FAILED 처리
         backupHistoryTransaction.fail(history, null);
+        eventPublisher.publishEvent(new BackupNotificationEvent(
+            "BACKUP_FAILED",
+            history.getStartedAt(),
+            history.getEndedAt(),
+            e.getMessage()
+        ));
       }
     }
     return backupHistoryMapper.toDto(history);
@@ -222,7 +237,6 @@ public class BackupHistoryService {
       }
     }
   }
-
 
 
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -29,7 +29,7 @@ public class DepartmentService {
         request.name(),
         request.description(),
         request.establishedDate(),
-        request.departmentEmail()
+        request.departmentMail()
     );
     Department saved = departmentRepository.save(department);
     return toDto(saved);
@@ -44,7 +44,7 @@ public class DepartmentService {
       throw new IllegalArgumentException("이미 존재하는 부서 이름입니다: " + request.name());
     }
     department.update(request.name(), request.description(), request.establishedDate(),
-        request.departmentEmail());
+        request.departmentMail());
     return toDto(department);
   }
 
@@ -94,7 +94,7 @@ public class DepartmentService {
         department.getCreatedAt(),
         department.getUpdatedAt(),
         count,
-        department.getDepartmentEmail()
+        department.getDepartmentMail()
     );
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeService.java
@@ -7,12 +7,14 @@ import com.hrbank3.hrbank3.dto.employee.EmployeeUpdateRequest;
 import com.hrbank3.hrbank3.entity.Department;
 import com.hrbank3.hrbank3.entity.Employee;
 import com.hrbank3.hrbank3.entity.FileMetadata;
+import com.hrbank3.hrbank3.event.EmployeeNotificationEvent;
 import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import com.hrbank3.hrbank3.repository.EmployeeRepository;
 import com.hrbank3.hrbank3.repository.condition.EmployeeSearchCondition;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,6 +26,8 @@ public class EmployeeService {
   private final EmployeeRepository employeeRepository;
   private final DepartmentRepository departmentRepository;
   private final FileService fileService;
+
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public EmployeeDto create(EmployeeCreateRequest request, MultipartFile profileImage) {
@@ -54,6 +58,7 @@ public class EmployeeService {
       );
 
       Employee savedEmployee = employeeRepository.save(employee);
+      eventPublisher.publishEvent(new EmployeeNotificationEvent("EMPLOYEE_CREATE", savedEmployee));
 
       // TODO: EmployeeAuditHistory 머지 후 이력 저장 연동 필요
       // AuditType.CREATED, targetEmployeeNo = savedEmployee.getEmployeeNumber()
@@ -145,6 +150,8 @@ public class EmployeeService {
   public void delete(Long id) {
     Employee employee = employeeRepository.findById(id)
         .orElseThrow(() -> new NoSuchElementException("직원을 찾을 수 없습니다."));
+
+    eventPublisher.publishEvent(new EmployeeNotificationEvent("EMPLOYEE_DELETE", employee));
 
     if (employee.getProfileImage() != null) {
       fileService.deletePhysicalFile(employee.getProfileImage().getStoragePath());

--- a/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
@@ -115,8 +115,8 @@ public class NotificationService {
     sb.append("시작 시각: ").append(event.startedAt()).append("\n");
     sb.append("완료(실패) 시각: ").append(event.endedAt()).append("\n");
 
-    if (event.eroorMessage() != null) {
-      sb.append("원인: ").append(event.eroorMessage());
+    if (event.errorMessage() != null) {
+      sb.append("원인: ").append(event.errorMessage());
     }
 
     return sb.toString();

--- a/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
@@ -33,7 +33,10 @@ public class NotificationService {
   @Transactional
   public void handleEmployeeNotification(EmployeeNotificationEvent event) {
     Department department = event.employee().getDepartment();
-    String recipientEmail = adminEmail;
+    // null 체크 추가
+    String recipientEmail = department.getDepartmentMail() != null
+        ? department.getDepartmentMail()
+        : adminEmail;
     String subject = event.eventType();
     String content = buildEmployeeContent(event);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     active: local
   mvc:
     format:
-      date-time: iso # 프론트 파싱을 위한 설정 -> 테스트 필요
+      date-time: iso
   servlet:
     multipart:
       enabled: true
@@ -23,9 +23,6 @@ spring:
           starttls:
             enable: true
 
-  notification:
-    admin-email: ${NOTIFICATION_ADMIN_EMAIL:admin@hrbank.com}
-
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -40,7 +37,10 @@ backup:
   dir: ${BACKUP_DIR:./backups/}
   chunk-size: 500
   schedule:
-    cron: "0 0 * * * *" # 매 시 정각에 하도록 세팅
+    cron: "0 0 * * * *"
+
+notification:
+  admin-email: ${NOTIFICATION_ADMIN_EMAIL:admin@hrbank.com}
 
 management:
   endpoints:
@@ -50,4 +50,3 @@ management:
   endpoint:
     health:
       show-details: never
-

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS departments (
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
     established_date DATE NOT NULL,
-    department_mail VARCHAR(255) NOT NULL,
+    department_mail VARCHAR(255),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS departments (
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
     established_date DATE NOT NULL,
-    depratment_mail VARCHAR(255) NOT NULL,
+    depratment_mail VARCHAR(255),
     created_at TIMESTAMPTZ NOT NULL,
     updated_at TIMESTAMPTZ NOT NULL
 );


### PR DESCRIPTION
## 관련 이슈
- closes #64 

### 알림 이벤트 발행
- EmployeeService.create() : 직원 등록 시 EmployeeNotificationEvent("EMPLOYEE_CREATE") 발행
- EmployeeService.delete(): 직원 삭제 시 EmployeeNotificationEvent("EMPLOYEE_DELETED") 발행
- BackupHistoryService.execute() : 백업 성공 시 BackupNotificationEvent("BACKUP_SUCCESS") 발행
- BackupHistoryService.execute() : 백업 실패 시 BackupNotificationEvent("BACKUP_FAILED") 발행

### departmentMail nullable 처리
부서 메일(departmentMail)은 직원 알림 발송 시 수신 대상 이메일로 사용되는 중요한 필드입니다.
원래 설계상 필수값으로 지정되었으나, 현재 프론트엔드 소스 수정이 불가능한 상황으로 인해
departmentMail 필드가 없는 요청이 들어올 경우 서버 오류가 발생하는 문제가 있었습니다.

이를 해결하기 위해 임시로 nullable 처리하였으며, departmentMail이 null인 경우
관리자 이메일(adminEmail)로 대체하여 알림이 정상 발송되도록 처리하였습니다.

추후 프론트엔드에서 departmentMail 입력 필드가 추가될 수 있다면, 다시 필수값으로 되돌리는 것을 권장합니다.

- DepartmentCreateRequest, DepartmentUpdateRequest에서 @NotBlank, @Email 제거
- Department 엔티티: departmentMail nullable 처리
- schema-h2.sql, schema-postgres.sql : department_mail에서 NOT NULL 제거
- NotificationService : departmentMail null 시 adminEmail로 대체

## 테스트
- [x] 직원 등록/삭제 → 알림 이벤트 발행 및 DB 저장 확인
- [x] 백업 성공/실패 → 알림 이벤트 발행 및 DB 저장 확인
- [x] departmentMail 없이 부서 등록 → 정상 동작 확인
- [x] 프론트엔드에서 부서 등록 → 정상 동작 확인