### PR TITLE
Feat: 수정 이력 건수 조회 API 구현 [#83]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeAuditHistoryController.java
@@ -20,6 +20,10 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.time.Instant;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "직원 정보 수정 이력 관리", description = "직원 정보 수정 이력 관리 API")
 @RestController
@@ -59,5 +63,20 @@ public class EmployeeAuditHistoryController {
   public ResponseEntity<CursorPageResponseDto<ChangeLogDto>> findAll(
       @ParameterObject @ModelAttribute ChangeLogSearchCondition condition) {
     return ResponseEntity.ok(auditHistoryService.findAll(condition));
+  }
+
+  @Operation(summary = "수정 이력 건수 조회", description = "직원 정보 수정 이력 건수를 조회합니다. 파라미터를 제공하지 않으면 최근 일주일 데이터를 반환합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "조회 성공"),
+
+  })
+  @GetMapping("/count")
+  public ResponseEntity<Long> getCount(
+          @Parameter(description = "시작 일시 (기본값: 7일 전)")
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant fromDate,
+          @Parameter(description = "종료 일시 (기본값: 현재)")
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant toDate
+  ) {
+    return ResponseEntity.ok(auditHistoryService.getCount(fromDate, toDate));
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/EmployeeAuditHistoryRepository.java
@@ -8,4 +8,6 @@ public interface EmployeeAuditHistoryRepository extends JpaRepository<EmployeeAu
 
     // 특정 시간 이후 생성된 수정 이력 건수 - 대시보드에서 사용
     long countByCreatedAtAfter(Instant createdAt);
+
+    long countByCreatedAtBetween(Instant from, Instant to);
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -23,6 +23,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -162,5 +164,16 @@ public class EmployeeAuditHistoryService {
   // 데이터 전달용 임시 레코드
   private record EmployeeInfo(String name, Long profileImageId) {
 
+  }
+
+  @Transactional(readOnly = true)
+  public long getCount(Instant fromDate, Instant toDate) {
+    if (fromDate == null) {
+      fromDate = Instant.now().minus(7, ChronoUnit.DAYS);
+    }
+    if (toDate == null) {
+      toDate = Instant.now();
+    }
+    return auditRepository.countByCreatedAtBetween(fromDate, toDate);
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #83 

## 변경사항
- EmployeeAuditHistoryController에 GET /api/change-logs/count API 추가
- EmployeeAuditHistoryService에 getCount() 메서드 추가
- EmployeeAuditHistoryRepository에 countByCreatedAtBetween() 메서드 추가
- fromDate, toDate 파라미터 미입력 시 기본값 적용 (fromDate: 7일 전, toDate: 현재)

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인