### PR TITLE
Feat: 부서 관리 API Swagger 응답 코드 추가 [#90]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/controller/DepartmentController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/DepartmentController.java
@@ -1,11 +1,16 @@
 package com.hrbank3.hrbank3.controller;
 
+import com.hrbank3.hrbank3.common.exception.ErrorResponse;
 import com.hrbank3.hrbank3.dto.CursorPageResponseDto;
-import com.hrbank3.hrbank3.dto.department.DepartmentDto;
 import com.hrbank3.hrbank3.dto.department.DepartmentCreateRequest;
+import com.hrbank3.hrbank3.dto.department.DepartmentDto;
 import com.hrbank3.hrbank3.dto.department.DepartmentUpdateRequest;
 import com.hrbank3.hrbank3.service.DepartmentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "부서 관리")  // Swagger 태그명 변경
+@Tag(name = "부서 관리", description = "부서 관리 API")
 @RestController
 @RequestMapping("/api/departments")
 @RequiredArgsConstructor
@@ -21,14 +26,30 @@ public class DepartmentController {
 
     private final DepartmentService departmentService;
 
-    @Operation(summary = "부서 등록")
+    @Operation(summary = "부서 등록", description = "새로운 부서를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 중복된 이름",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping
     public ResponseEntity<DepartmentDto> create(@Valid @RequestBody DepartmentCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(departmentService.create(request));
     }
 
-    @Operation(summary = "부서 수정")
+    @Operation(summary = "부서 수정", description = "부서 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 중복된 이름",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PatchMapping("/{id}")
     public ResponseEntity<DepartmentDto> update(
             @PathVariable Long id,
@@ -36,26 +57,50 @@ public class DepartmentController {
         return ResponseEntity.ok(departmentService.update(id, request));
     }
 
-    @Operation(summary = "부서 삭제")
+    @Operation(summary = "부서 삭제", description = "부서를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "소속 직원이 있는 부서는 삭제할 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         departmentService.delete(id);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "부서 목록 조회")
+    @Operation(summary = "부서 목록 조회", description = "부서 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping
     public ResponseEntity<CursorPageResponseDto<DepartmentDto>> findAll(
             @RequestParam(required = false) String nameOrDescription,
             @RequestParam(defaultValue = "name") String sortField,
             @RequestParam(defaultValue = "asc") String sortDirection,
             @RequestParam(required = false) Long idAfter,
+            @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(
-                departmentService.findAll(nameOrDescription, sortField, sortDirection, idAfter, size));
+                departmentService.findAll(nameOrDescription, sortField, sortDirection, idAfter, cursor, size));
     }
 
-    @Operation(summary = "부서 단건 조회")
+    @Operation(summary = "부서 단건 조회", description = "부서 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/{id}")
     public ResponseEntity<DepartmentDto> findById(@PathVariable Long id) {
         return ResponseEntity.ok(departmentService.findById(id));

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryCustom.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryCustom.java
@@ -10,6 +10,7 @@ public interface DepartmentRepositoryCustom {
             String sortField,
             String sortDirection,
             Long idAfter,
+            String cursor,  // 추가
             int size
     );
 }

--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -25,7 +25,8 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
       String nameOrDescription,
       String sortField,       // sortBy → sortField
       String sortDirection,
-      Long idAfter,           // lastId → idAfter
+      Long idAfter,     // lastId → idAfter
+      String cursor,
       int size) {
 
     QDepartment department = QDepartment.department;

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -69,9 +69,10 @@ public class DepartmentService {
       String sortField,
       String sortDirection,
       Long idAfter,
+      String cursor,
       int size) {
     return departmentRepository.findAllWithCursor(
-        nameOrDescription, sortField, sortDirection, idAfter, size);
+        nameOrDescription, sortField, sortDirection, idAfter,cursor, size);
   }
 
   // 부서 단건 조회


### PR DESCRIPTION
## 관련 이슈
- closes #90

## 변경사항
- DepartmentController 각 API에 @ApiResponses 어노테이션 추가
  - 부서 등록: 200, 400, 500
  - 부서 수정: 200, 400, 404, 500
  - 부서 삭제: 204, 400, 404, 500
  - 부서 목록 조회: 200, 400, 500
  - 부서 단건 조회: 200, 404, 500
- 부서 목록 조회 API에 cursor 파라미터 추가

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인