### PR TITLE
Fix: 깃 설정 변경 및 에러 수정 [#91]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+
+*.woff2 binary
+*.woff binary
+*.ttf binary
+*.otf binary

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Thumbs.db
 
 # File Uploads (로컬 테스트용 폴더 제외)
 /uploads/
+/backups/

--- a/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/BackupHistoryController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.ZonedDateTime;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -40,9 +39,9 @@ public class BackupHistoryController {
   })
   public ResponseEntity<BackupHistoryDto> getLatestBackup(
       @RequestParam(defaultValue = "COMPLETED") String status) {
-    return backupHistoryService.getLatestBackup(status)
-        .map(ResponseEntity::ok)
-        .orElseThrow(() -> new NoSuchElementException("백업 이력이 없습니다"));
+    return ResponseEntity.ok(
+        backupHistoryService.getLatestBackup(status).orElse(null)
+    );
   }
 
   // 데이터 백업 목록 조회 api (GET)

--- a/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
+++ b/src/main/java/com/hrbank3/hrbank3/controller/EmployeeController.java
@@ -71,6 +71,20 @@ public class EmployeeController {
     return ResponseEntity.ok(employeeService.findAll(condition));
   }
 
+  @Operation(summary = "직원 수 조회", description = "지정된 조건에 맞는 직원 수를 조회합니다. 상태 필터링 및 입사일 기간 필터링이 가능합니다.")
+  @GetMapping("/count")
+  public ResponseEntity<Long> getEmployeeCount(
+      @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사)", schema = @Schema(allowableValues = {"ACTIVE",
+          "ON_LEAVE", "RESIGNED"}))
+      @RequestParam(required = false) EmployeeStatus status,
+      @Parameter(description = "입사일 시작 (지정 시 해당 기간 내 입사한 직원 수 조회, 미지정 시 전체 직원 수 조회)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+      @Parameter(description = "입사일 종료 (fromDate와 함께 사용, 기본값: 현재 일시)")
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
+  ) {
+    return ResponseEntity.ok(dashboardService.getEmployeeCount(status, fromDate, toDate));
+  }
+
   @Operation(summary = "직원 상세 조회")
   @GetMapping("/{id}")
   public ResponseEntity<EmployeeDto> findById(@PathVariable Long id) {
@@ -117,19 +131,5 @@ public class EmployeeController {
       @RequestParam(required = false) EmployeeStatus status
   ) {
     return ResponseEntity.ok(dashboardService.getDistribution(groupBy, status));
-  }
-
-  @Operation(summary = "직원 수 조회", description = "지정된 조건에 맞는 직원 수를 조회합니다. 상태 필터링 및 입사일 기간 필터링이 가능합니다.")
-  @GetMapping("/count")
-  public ResponseEntity<Long> getEmployeeCount(
-      @Parameter(description = "직원 상태 (재직중, 휴직중, 퇴사)", schema = @Schema(allowableValues = {"ACTIVE",
-          "ON_LEAVE", "RESIGNED"}))
-      @RequestParam(required = false) EmployeeStatus status,
-      @Parameter(description = "입사일 시작 (지정 시 해당 기간 내 입사한 직원 수 조회, 미지정 시 전체 직원 수 조회)")
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
-      @Parameter(description = "입사일 종료 (fromDate와 함께 사용, 기본값: 현재 일시)")
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
-  ) {
-    return ResponseEntity.ok(dashboardService.getEmployeeCount(status, fromDate, toDate));
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
+++ b/src/main/java/com/hrbank3/hrbank3/dto/department/DepartmentUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.hrbank3.hrbank3.dto.department;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -15,8 +14,6 @@ public record DepartmentUpdateRequest(
     @NotNull(message = "설립일은 필수입니다")
     LocalDate establishedDate,
 
-    @NotBlank(message = "부서 메일은 필수입니다")
-    @Email(message = "이메일 형식이 올바르지 않습니다")
     String departmentMail
 ) {
 


### PR DESCRIPTION
## 관련 이슈
- closes #91 

## 변경사항
- gitignore에 backup 폴더 경로 추가
- gitattribute에 폰트를 바이너리로 고정하도록 추가
- BackupHistoryController에서 최신 백업 조회를 했을 때 데이터가 없을시 404를 반환하도록 했는데, 경로가 잘못되어 404인지 데이터가 없는건지 구분이 안 가는 이슈 -> 404가 아닌 null을 반환하도록 수정
- EmployeeController에서 @GetMapping의 경로 /count로 요청이 가야하는 것이 /{id}로 먼저 가서 타입에러가 발생 후 /count를 다시 찾아 작동되고 있었음. -> /count 경로의 메서드를 /{id} 경로의 메서드보다 위쪽으로 올려서 해결함


## 테스트
- [x] 로컬 테스트 완료

## 스크린샷 (선택)
