### PR TITLE
Fix: DepartmentRepositoryImpl cursor 파라미터 실제 적용 [#96]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/DepartmentRepositoryImpl.java
@@ -22,12 +22,12 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
 
   @Override
   public CursorPageResponseDto<DepartmentDto> findAllWithCursor(
-      String nameOrDescription,
-      String sortField,       // sortBy → sortField
-      String sortDirection,
-      Long idAfter,     // lastId → idAfter
-      String cursor,
-      int size) {
+          String nameOrDescription,
+          String sortField,
+          String sortDirection,
+          Long idAfter,
+          String cursor,
+          int size) {
 
     QDepartment department = QDepartment.department;
     QEmployee employee = QEmployee.employee;
@@ -36,35 +36,42 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
     // 키워드 필터링
     if (nameOrDescription != null && !nameOrDescription.isBlank()) {
       builder.and(
-          department.name.containsIgnoreCase(nameOrDescription)
-              .or(department.description.containsIgnoreCase(nameOrDescription))
+              department.name.containsIgnoreCase(nameOrDescription)
+                      .or(department.description.containsIgnoreCase(nameOrDescription))
       );
     }
 
     // 전체 개수 조회
     long totalElements = queryFactory
-        .selectFrom(department)
-        .where(builder)
-        .fetchCount();
+            .selectFrom(department)
+            .where(builder)
+            .fetchCount();
 
-    // 커서 조건 추가
-    if (idAfter != null) {
+    // 커서 조건 추가 (cursor가 있으면 cursor 사용, 없으면 idAfter 사용)
+    if (cursor != null && !cursor.isBlank()) {
+      try {
+        Long cursorId = Long.parseLong(cursor);
+        builder.and(department.id.gt(cursorId));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("유효하지 않은 cursor 값입니다: " + cursor);
+      }
+    } else if (idAfter != null) {
       builder.and(department.id.gt(idAfter));
     }
 
     // 정렬 및 조회
     List<Department> results = queryFactory
-        .selectFrom(department)
-        .where(builder)
-        .orderBy("desc".equals(sortDirection)
-            ? ("establishedDate".equals(sortField)
-               ? department.establishedDate.desc()
-            : department.name.desc())
-            : ("establishedDate".equals(sortField)
-               ? department.establishedDate.asc()
-                : department.name.asc()))
-        .limit(size + 1)
-        .fetch();
+            .selectFrom(department)
+            .where(builder)
+            .orderBy("desc".equals(sortDirection)
+                    ? ("establishedDate".equals(sortField)
+                    ? department.establishedDate.desc()
+                    : department.name.desc())
+                    : ("establishedDate".equals(sortField)
+                    ? department.establishedDate.asc()
+                    : department.name.asc()))
+            .limit(size + 1)
+            .fetch();
 
     // 다음 페이지 여부 확인
     boolean hasNext = results.size() > size;
@@ -74,36 +81,36 @@ public class DepartmentRepositoryImpl implements DepartmentRepositoryCustom {
 
     // employeeCount 실제 조회
     List<DepartmentDto> content = results.stream()
-        .map(d -> {
-          Long count = queryFactory
-              .select(employee.count())
-              .from(employee)
-              .where(employee.department.eq(d),
-                  employee.status.ne(EmployeeStatus.RESIGNED))
-              .fetchOne();
-          return new DepartmentDto(
-              d.getId(),
-              d.getName(),
-              d.getDescription(),
-              d.getEstablishedDate(),
-              d.getCreatedAt(),
-              d.getUpdatedAt(),
-              count != null ? count : 0L,
-              d.getDepartmentMail()
-          );
-        })
-        .collect(Collectors.toList());
+            .map(d -> {
+              Long count = queryFactory
+                      .select(employee.count())
+                      .from(employee)
+                      .where(employee.department.eq(d),
+                              employee.status.ne(EmployeeStatus.RESIGNED))
+                      .fetchOne();
+              return new DepartmentDto(
+                      d.getId(),
+                      d.getName(),
+                      d.getDescription(),
+                      d.getEstablishedDate(),
+                      d.getCreatedAt(),
+                      d.getUpdatedAt(),
+                      count != null ? count : 0L,
+                      d.getDepartmentMail()
+              );
+            })
+            .collect(Collectors.toList());
 
     String nextCursor = hasNext ? String.valueOf(results.get(results.size() - 1).getId()) : null;
     Long nextIdAfter = hasNext ? results.get(results.size() - 1).getId() : null;
 
     return new CursorPageResponseDto<>(
-        content,
-        nextCursor,
-        nextIdAfter,
-        content.size(),
-        totalElements,
-        hasNext
+            content,
+            nextCursor,
+            nextIdAfter,
+            content.size(),
+            totalElements,
+            hasNext
     );
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #96 

## 변경사항
- DepartmentRepositoryImpl에 cursor 파싱 로직 추가
- cursor가 있으면 cursor를 Long으로 변환하여 idAfter 대신 사용
- cursor와 idAfter 둘 다 없으면 첫 페이지 조회
- 유효하지 않은 cursor 값 입력 시 예외 처리 추가

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인