### PR TITLE
Fix: 부서 삭제 시 알림 FK 제약조건 위반 오류 수정 [#103]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/repository/NotificationRepository.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/NotificationRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+  void deleteByDepartmentId(Long departmentId);
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/DepartmentService.java
@@ -8,6 +8,7 @@ import com.hrbank3.hrbank3.entity.Department;
 import com.hrbank3.hrbank3.entity.enums.EmployeeStatus;
 import com.hrbank3.hrbank3.repository.DepartmentRepository;
 import com.hrbank3.hrbank3.repository.EmployeeRepository;
+import com.hrbank3.hrbank3.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ public class DepartmentService {
 
   private final DepartmentRepository departmentRepository;
   private final EmployeeRepository employeeRepository;
+  private final NotificationRepository notificationRepository;
 
   // 부서 등록
   public DepartmentDto create(DepartmentCreateRequest request) {
@@ -59,6 +61,7 @@ public class DepartmentService {
     if (hasEmployees) {
       throw new IllegalStateException("소속 직원이 있는 부서는 삭제할 수 없습니다.");
     }
+    notificationRepository.deleteByDepartmentId(id);
     departmentRepository.delete(department);
   }
 
@@ -72,7 +75,7 @@ public class DepartmentService {
       String cursor,
       int size) {
     return departmentRepository.findAllWithCursor(
-        nameOrDescription, sortField, sortDirection, idAfter,cursor, size);
+        nameOrDescription, sortField, sortDirection, idAfter, cursor, size);
   }
 
   // 부서 단건 조회


### PR DESCRIPTION
## 관련 이슈
- closes #103 

## 변경사항
부서 삭제 시 notifications 테이블에 해당 부서를 참조하는 데이터가 존재할 경우
FK 제약조건 위반으로 500 에러가 발생하는 문제를 수정하였습니다.

- `NotificationRepository`: `deleteByDepartmentId()` 메서드 추가
- `DepartmentService.delete()`: 부서 삭제 전 해당 부서의 알림 데이터 먼저 삭제

## 테스트
- [x] 로컬 테스트 완료
- [x] API 문서(Swagger) 확인
