### PR TITLE
Refactor: 오타 수정 및 인덱스 변경 & 분리[#108]

### DIFF
--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -42,7 +42,7 @@ CREATE INDEX IF NOT EXISTS idx_emp_name ON employees (name);
 CREATE INDEX IF NOT EXISTS idx_emp_email ON employees (email);
 CREATE INDEX IF NOT EXISTS idx_emp_department ON employees (department_id);
 CREATE INDEX IF NOT EXISTS idx_emp_position ON employees (position);
-CREATE INDEX IF NOT EXISTS idx_employ_number ON employees (employee_number);
+CREATE INDEX IF NOT EXISTS idx_employee_number ON employees (employee_number);
 CREATE INDEX IF NOT EXISTS idx_emp_status_hire_date ON employees (status, hire_date DESC);
 
 -- 4. employee_audit_histories 테이블 생성

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS departments (
     updated_at TIMESTAMPTZ NOT NULL
 );
 -- 이름 또는 설명 (부분 일치 조건으로 인덱스 생성)
-CREATE INDEX IF NOT EXISTS idx_department_name_desc ON departments USING gin(name gin_trgm_ops, description gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_department_name_desc ON departments USING gin(name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_department_description ON departments USING gin(description gin_trgm_ops);
 
 -- 2. files 테이블 생성
 CREATE TABLE IF NOT EXISTS files (
@@ -41,11 +42,12 @@ CREATE TABLE IF NOT EXISTS employees (
     CONSTRAINT fk_profile_image FOREIGN KEY (profile_image_id) REFERENCES files(id)
 );
 -- 이름 또는 이메일 (부분 일치 조건으로 인덱스 생성)
-CREATE INDEX IF NOT EXISTS idx_name_email ON employees USING  gin(name gin_trgm_ops, email gin_trgm_ops);
--- 부서ID (부서명 검색 시 departments 테이블과 빠른 조인을 위하여 일반 인덱스 사용)
-CREATE INDEX IF NOT EXISTS idx_emp_department_id On employees (department_id);
+CREATE INDEX IF NOT EXISTS idx_name ON employees USING gin(name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_email ON employees USING gin(email gin_trgm_ops);
+-- 부서ID (특정 부서 직원 검색(WHERE), 참조 무결성 연산(CASCADE/SET NULL) 및  nested loop 조인 성능 최적화)
+CREATE INDEX IF NOT EXISTS idx_emp_department_id ON employees (department_id);
 -- 직함 (부분 일치)
-CREATE INDEX IF NOT EXISTS idx_position ON employees USING gin(position gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_position ON employees (position);
 -- 사원번호 (부분 일치)
 CREATE INDEX IF NOT EXISTS idx_employee_number ON employees USING gin(employee_number gin_trgm_ops);
 -- 상태 및 입사일 (완전 일치인 상태를 앞에 두어 상태를 기준으로 먼저 정렬 후 입사일 범위 조건)


### PR DESCRIPTION
## 관련 이슈
- closes #108

## 변경사항
- department 테이블의 GIN 복합 인덱스를 분리하였습니다.
- 사이 공백 및 오타 수정
- department_id 인덱스의 주석을 수정하였습니다.
- employee 테이블의 GIN 복합 인덱스를 분리하였습니다.
- h2.sql파일 내부의 오타 수정

## 테스트
- [x] 로컬 테스트 완료

## 스크린샷 (선택)


## 추가 사항
- 현재 postgres.sql파일 내부에 ip_address가 VARCHAR(50)으로 선언되어 있는데, PostgreSQL에는 inet 타입이 있어 IPv4/IPv6를 일관되게 저장하고 CIDR/서브넷 검색(<<, >>=)을 기본 지원하여 같은 대역에서 온 요청" 같은 분석이 필요하다면 inet이 훨씬 유리하다는 피드백을 받았습니다. 하지만 현 단계에선 ip_address와 연관된 부분의 수정이 필요할 수 있어 큰 변경이될 수 있어, 변경은 하지 않았습니다. 배포 이후 버전 업데이트 과정에서 변경을 해보게되면 좋을 것 같습니다.