### PR TITLE
Fix: 백업 파일 다운로드 시 경로 중복으로 인한 에러 수정[#115]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/service/FileService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/FileService.java
@@ -109,8 +109,14 @@ public class FileService {
         .orElseThrow(() -> new IllegalArgumentException("해당 ID의 파일 메타데이터를 찾을 수 없습니다."));
 
     try {
-      // 메타 정보에 기록된 경로를 통해 로컬 파일에 접근
-      Path filePath = Paths.get(uploadPath).resolve(fileMetadata.getStoragePath()).normalize();
+      // storagePath가 전체 경로(백업 파일)인지 파일명만(프로필 이미지)인지 판단
+      String storagePath = fileMetadata.getStoragePath();
+      Path filePath;
+      if(storagePath.contains("/") || storagePath.contains("\\")) {
+        filePath = Paths.get(storagePath);
+      } else {
+        filePath = Paths.get(uploadPath).resolve(fileMetadata.getStoragePath()).normalize();
+      }
       Resource resource = new UrlResource(filePath.toUri());
 
       // 물리적 파일이 디스크에서 삭제되어있는지 확인


### PR DESCRIPTION
## 관련 이슈
- closes #115 

## 변경사항
storagePath에 경로 구분자(/, \) 포함 여부로 전체 경로인지 파일명만인지 판단하여 uploadPath 조합 여부를 결정하도록 수정
- 전체 경로인 경우 (백업 파일) → storagePath 그대로 사용
- 파일명만인 경우 (프로필 이미지) → uploadPath + storagePath 조합

## 테스트
- [x] 로컬 테스트 완료

## 스크린샷 (선택)
