### PR TITLE
Refactor: 비동기 알림 처리 및 STMP -> Mailtrap API 방식 전환 [#116]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/Hrbank3Application.java
+++ b/src/main/java/com/hrbank3/hrbank3/Hrbank3Application.java
@@ -3,7 +3,9 @@ package com.hrbank3.hrbank3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class Hrbank3Application {

--- a/src/main/java/com/hrbank3/hrbank3/config/WebConfig.java
+++ b/src/main/java/com/hrbank3/hrbank3/config/WebConfig.java
@@ -2,7 +2,9 @@ package com.hrbank3.hrbank3.config;
 
 import java.io.File;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry.addResourceHandler("/uploads/**")
         .addResourceLocations("file:" + new File(uploadPath).getAbsolutePath() + "/");
+  }
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
   }
 }

--- a/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
@@ -34,7 +34,7 @@ public class NotificationService {
   @Value("${notification.admin-email}")
   private String adminEmail;
 
-  @Value("${mailtrap.api-token}")
+  @Value("${mailtrap.api-token:}")
   private String mailtrapApiToken;
 
   private static final String MAILTRAP_API_URL = "https://sandbox.api.mailtrap.io/api/send/4562077";

--- a/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/NotificationService.java
@@ -6,29 +6,41 @@ import com.hrbank3.hrbank3.entity.enums.NotificationStatus;
 import com.hrbank3.hrbank3.event.BackupNotificationEvent;
 import com.hrbank3.hrbank3.event.EmployeeNotificationEvent;
 import com.hrbank3.hrbank3.repository.NotificationRepository;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
-  private final JavaMailSender mailSender;
   private final NotificationRepository notificationRepository;
+  private final RestTemplate restTemplate;
 
   @Value("${notification.admin-email}")
   private String adminEmail;
 
+  @Value("${mailtrap.api-token}")
+  private String mailtrapApiToken;
+
+  private static final String MAILTRAP_API_URL = "https://sandbox.api.mailtrap.io/api/send/4562077";
+
   // 직원 알림 이벤트
+  @Async
   @EventListener
   @Transactional
   public void handleEmployeeNotification(EmployeeNotificationEvent event) {
@@ -44,6 +56,7 @@ public class NotificationService {
   }
 
   // 백업 알림 이벤트
+  @Async
   @EventListener
   @Transactional
   public void handleBackupNotification(BackupNotificationEvent event) {
@@ -75,16 +88,20 @@ public class NotificationService {
     notificationRepository.save(notification);
   }
 
-  // 실제 메일 발송
-  private void sendMail(String to, String subject, String content) throws MessagingException {
-    // Multipurpose Internet Mail Extension : 한글, 첨부파일, HTML 지원
-    MimeMessage message = mailSender.createMimeMessage();
-    MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-    helper.setTo(to);
-    helper.setSubject(subject);
-    // 현재는 단순 텍스트라서 true로 변경시 HTML 형식으로 바꾸고 build*Content() 내용 수정해야 함
-    helper.setText(content, false);
-    mailSender.send(message);
+  // Mailtrap API로 메일 발송
+  private void sendMail(String to, String subject, String content) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(mailtrapApiToken);
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("from", Map.of("email", "sb11_team3@hrbank.com", "name", "HRBANK"));
+    body.put("to", List.of(Map.of("email", to)));
+    body.put("subject", subject);
+    body.put("html", content);
+
+    HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+    restTemplate.postForObject(MAILTRAP_API_URL, request, String.class);
   }
 
   // 직원 알림 메일 내용

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,11 +4,6 @@ spring:
     url: jdbc:postgresql://localhost:5432/hrbank
     username: ${DB_USER}
     password: ${DB_PASSWORD}
-  mail:
-    host: sandbox.smtp.mailtrap.io
-    port: 2525
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
 
   sql:
     init:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -10,12 +10,6 @@ spring:
   sql:
     init:
       mode: never
-  mail:
-    host: sandbox.smtp.mailtrap.io
-    port: 2525
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -16,3 +16,6 @@ logging:
     root: WARN
     com.yourpackage: INFO
 
+mailtrap:
+  api-token: ${MAILTRAP_API_TOKEN:}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,9 +31,6 @@ backup:
 notification:
   admin-email: ${NOTIFICATION_ADMIN_EMAIL:admin@hrbank.com}
 
-mailtrap:
-  api-token: ${MAILTRAP_API_TOKEN:}
-
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,17 +11,6 @@ spring:
       enabled: true
       max-file-size: 10MB
       max-request-size: 50MB
-  mail:
-    host: sandbox.smtp.mailtrap.io
-    port: 2525
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
 
 springdoc:
   swagger-ui:
@@ -41,6 +30,9 @@ backup:
 
 notification:
   admin-email: ${NOTIFICATION_ADMIN_EMAIL:admin@hrbank.com}
+
+mailtrap:
+  api-token: ${MAILTRAP_API_TOKEN:}
 
 management:
   endpoints:


### PR DESCRIPTION
## 관련 이슈
- closes #116 

## 변경사항
- `Hrbank3Application`: `@EnableAsync` 추가
- `NotificationService`: `@Async` 적용으로 메일 발송 비동기 처리
- `NotificationService`: `JavaMailSender` → `RestTemplate` + Mailtrap HTTP API 방식으로 전환
- `WebConfig`: `RestTemplate` Bean 추가
- `application.yaml`: `spring.mail` 제거, `mailtrap.api-token` 추가

## 테스트
- [x] 로컬 테스트 완료 - 직원 등록/삭제, 백업 시 Mailtrap 메일 수신 확인
- [x] 비동기 처리로 응답 속도 개선 확인

## 참고
- Railway 프리티어 SMTP 포트(25, 465, 587) 차단으로 인해 HTTP API 방식으로 전환
- Railway Variables에 `MAILTRAP_API_TOKEN` 설정 필요