### PR TITLE
Fix: 직원 목록 커서 페이지네이션 보조 정렬 기준 id 추가 [#125]

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/repository/custom/EmployeeRepositoryImpl.java
+++ b/src/main/java/com/hrbank3/hrbank3/repository/custom/EmployeeRepositoryImpl.java
@@ -121,15 +121,21 @@ public class EmployeeRepositoryImpl implements EmployeeRepositoryCustom {
     return idAfter != null ? employee.id.gt(idAfter) : null;
   }
 
-  private OrderSpecifier<?> resolveOrderBy(String sortField, String sortDirection) {
+  private OrderSpecifier<?>[] resolveOrderBy(String sortField, String sortDirection) {
     // 대소문자 구분 없이 비교, desc 와 DESC는 같음
     boolean isAsc = !"desc".equalsIgnoreCase(sortDirection);
     if ("employeeNumber".equals(sortField)) {
-      return isAsc ? employee.employeeNumber.asc() : employee.employeeNumber.desc();
+      return isAsc
+          ? new OrderSpecifier[]{employee.employeeNumber.asc(), employee.id.asc()}
+          : new OrderSpecifier[]{employee.employeeNumber.desc(), employee.id.desc()};
     }
     if ("hireDate".equals(sortField)) {
-      return isAsc ? employee.hireDate.asc() : employee.hireDate.desc();
+      return isAsc
+          ? new OrderSpecifier[]{employee.hireDate.asc(), employee.id.asc()}
+          : new OrderSpecifier[]{employee.hireDate.desc(), employee.id.desc()};
     }
-    return isAsc ? employee.name.asc() : employee.name.desc();
+    return isAsc
+        ? new OrderSpecifier[]{employee.name.asc(), employee.id.asc()}
+        : new OrderSpecifier[]{employee.name.desc(), employee.id.desc()};
   }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -27,3 +27,6 @@ file:
 backup:
   schedule:
     cron: "-" # 로컬에선 스케줄러 주기 비활성화
+
+mailtrap:
+  api-token: 32a36445711984266993bab519d5e799


### PR DESCRIPTION
## 관련 이슈
- closes #125

## 변경사항
- `EmployeeRepositoryImpl`: `resolveOrderBy()`에 보조 정렬 기준으로 `id` 추가
- 동일한 정렬값(name, hireDate, employeeNumber)을 가진 데이터가 여러 개일 때
  커서 페이지네이션이 정상 동작하도록 수정

## 테스트
- [x] 로컬 테스트 완료