### PR TITLE
Refactor: 직원 정보 수정 이력 상세 조회 API 리팩터링

### DIFF
--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +30,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmployeeAuditHistoryService {
@@ -140,7 +142,10 @@ public class EmployeeAuditHistoryService {
                 .map(DiffDto::before)
                 .findFirst()
                 .filter(val -> !"-".equals(val) && !"null".equals(val))
-                .orElse(null);
+                .orElseGet(() -> {
+                  log.warn("직원 사번 스냅샷 복원 실패: {}", audit.getId());
+                  return null;
+                });
 
             Long recoveredProfileId = diffs.stream()
                 .filter(d -> "profileImageId".equals(d.propertyName()))
@@ -154,7 +159,10 @@ public class EmployeeAuditHistoryService {
                     return null;
                   }
                 })
-                .orElse(null);
+                .orElseGet(() -> {
+                  log.info("직원 프로필 아이디 스냅샷 복원 실패: {}", audit.getId());
+                  return null;
+                });
             return new EmployeeInfo(recoveredName, recoveredProfileId);
           }
           return new EmployeeInfo(null, null);

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -39,7 +39,13 @@ public class EmployeeAuditHistoryService {
   private final EmployeeAuditHistoryRepositoryCustom customAuditRepository;
   private final EmployeeRepository employeeRepository;
 
-  // 직원 정보 수정 시 발생하는 핸들링
+
+  /*
+   * 직원 정보 수정 시 발생하는 이벤트 핸들링
+   * 메인 비즈니스 로직의 응답 속도 저하를 막고,
+   * 이력 저장이 실패하더라도 메인 트랜잭션이 롤백되지 않도록
+   * 의도적으로 비동기 처리(@Async) 및 트랜잭션을 분리(AFTER_COMMIT)하였습니다.
+   */
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void recordAuditHistory(EmployeeAuditEvent event) {

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -22,9 +22,11 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.StringUtils;
 
 @Service
@@ -36,8 +38,8 @@ public class EmployeeAuditHistoryService {
   private final EmployeeRepository employeeRepository;
 
   // 직원 정보 수정 시 발생하는 핸들링
-  @Transactional
-  @EventListener
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void recordAuditHistory(EmployeeAuditEvent event) {
     Map<String, Object> changedContent = extractDiff(event.beforeData(), event.afterData());
 

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -74,12 +74,15 @@ public class EmployeeAuditHistoryService {
     }
 
     for (String key : allKeys) {
-      Object before =
-          (beforeData != null && beforeData.get(key) != null) ? beforeData.get(key) : "-";
-      Object after = (afterData != null && afterData.get(key) != null) ? afterData.get(key) : "-";
+      Object before = (beforeData != null) ? beforeData.get(key) : null;
+      Object after = (afterData != null) ? afterData.get(key) : null;
 
       if (!Objects.equals(before, after)) {
-        diffMap.put(key, Map.of("before", before, "after", after));
+        Map<String, Object> diffEntry = new HashMap<>();
+        diffEntry.put("before", before);
+        diffEntry.put("after", after);
+
+        diffMap.put(key, diffEntry);
       }
     }
     return diffMap;
@@ -105,11 +108,13 @@ public class EmployeeAuditHistoryService {
             return new DiffDto(entry.getKey(), "-", "-");
           }
 
-          return new DiffDto(
-              entry.getKey(),
-              String.valueOf(values.get("before")),
-              String.valueOf(values.get("after"))
-          );
+          Object beforeRaw = values.get("before");
+          Object afterRaw = values.get("after");
+
+          String beforeStr = beforeRaw == null ? null : String.valueOf(beforeRaw);
+          String afterStr = afterRaw == null ? null : String.valueOf(afterRaw);
+
+          return new DiffDto(entry.getKey(), beforeStr, afterStr);
         })
         .toList();
 
@@ -140,8 +145,8 @@ public class EmployeeAuditHistoryService {
             String recoveredName = diffs.stream()
                 .filter(d -> "name".equals(d.propertyName()))
                 .map(DiffDto::before)
+                .filter(val -> val != null && !"-".equals(val))
                 .findFirst()
-                .filter(val -> !"-".equals(val) && !"null".equals(val))
                 .orElseGet(() -> {
                   log.warn("직원 사번 스냅샷 복원 실패: {}", audit.getId());
                   return null;
@@ -150,8 +155,8 @@ public class EmployeeAuditHistoryService {
             Long recoveredProfileId = diffs.stream()
                 .filter(d -> "profileImageId".equals(d.propertyName()))
                 .map(DiffDto::before)
+                .filter(val -> val != null && !"-".equals(val))
                 .findFirst()
-                .filter(val -> !"-".equals(val) && !"null".equals(val))
                 .map(val -> {
                   try {
                     return Long.parseLong(val);

--- a/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
+++ b/src/main/java/com/hrbank3/hrbank3/service/EmployeeAuditHistoryService.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -91,7 +92,7 @@ public class EmployeeAuditHistoryService {
   @Transactional(readOnly = true)
   public ChangeLogDetailDto find(Long id) {
     EmployeeAuditHistory audit = auditRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
+        .orElseThrow(() -> new NoSuchElementException("이력을 찾을 수 없습니다."));
 
     List<DiffDto> diffs = audit.getChangedContent().entrySet().stream()
         .map(entry -> {


### PR DESCRIPTION
## 관련 이슈
- closes #87 

## 변경사항
멘토님의 코드 리뷰 피드백을 반영하여, 직원 이력 저장 및 조회 로직의 안정성을 강화하고 잠재적인 에러(NPE)를 방어하는 리팩토링을 진행했습니다.

- [x] 이력 상세 조회 실패 시 404 에러(`NoSuchElementException`) 응답으로 예외 처리 개선
- [x] 이력 저장 로직을 `@Async` 및 `@TransactionalEventListener(AFTER_COMMIT)`로 분리하여 트랜잭션 안정성 확보
- [x] 삭제된 직원 이력 복원 시 데이터 누락을 추적하기 위한 방어 로직 및 로그(warn, info) 추가
- [x] 변경 내역 추출 시 매직 스트링("-")을 제거하고, HashMap과 Stream 선행 필터를 적용하여 잠재적 NPE 방어

## 스크린샷 (선택)
